### PR TITLE
Refactor/isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,10 @@ other packages coming in less than 10 seconds.
 Furthermore, when looking at subsequent layers, neither Matrix or mgcv and its dependencies have any relation
 to stringi, so there is no reason to wait for the layer to complete.
 
+# Development
+
+run all tests with tabular output: 
+
+```
+go test ./... -json -cover | tparse -all 
+```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ import (
 )
 
 // VERSION is the current pkc version
-const VERSION string = "0.0.1-alpha.3"
+const VERSION string = "0.0.1-beta.1"
 
 var log *logrus.Logger
 var fs afero.Fs

--- a/cran/download-package.go
+++ b/cran/download-package.go
@@ -1,7 +1,6 @@
 package cran
 
 import (
-	"crypto/md5"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -10,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dpastoor/goutils"
 	"github.com/spf13/afero"
@@ -29,11 +29,33 @@ const (
 	Binary
 )
 
+func getRepos(ds []PkgDl) map[string]RepoURL {
+	rpm := make(map[string]RepoURL)
+	for _, d := range ds {
+		rpm[d.Config.Repo.Name] = d.Config.Repo
+	}
+	return rpm
+}
+
 // DownloadPackages downloads a set of packages concurrently
 func DownloadPackages(fs afero.Fs, ds []PkgDl, baseDir string) (*PkgMap, error) {
+	startTime := time.Now()
 	result := NewPkgMap()
 	sem := make(chan struct{}, 10)
 	wg := sync.WaitGroup{}
+	rpm := getRepos(ds)
+	for _, r := range rpm {
+		urlHash := RepoURLHash(r)
+		for _, pt := range []string{"src", "binary"} {
+			pkgdir := filepath.Join(baseDir, urlHash, pt)
+			err := fs.MkdirAll(pkgdir, 0777)
+			if err != nil {
+				fmt.Println("error creating package directory ", pkgdir)
+				fmt.Println("error: ", err)
+				return result, err
+			}
+		}
+	}
 	for _, d := range ds {
 		wg.Add(1)
 		go func(d PkgDl, wg *sync.WaitGroup) {
@@ -54,26 +76,16 @@ func DownloadPackages(fs afero.Fs, ds []PkgDl, baseDir string) (*PkgMap, error) 
 				<-sem
 				wg.Done()
 			}()
-			h := md5.New()
-			// don't hash everything as still want a reasonable identifier
-			io.WriteString(h, d.Config.Repo.URL)
-			urlhash := fmt.Sprintf("%x", h.Sum(nil))
 			// TODO: should potentially provide a lookup mapping
 			// but would want to do this outside the goroutine that downloads\
 			// the package so didn't get invoked multiple times
-			pkgdir := filepath.Join(baseDir, d.Config.Repo.Name+"-"+urlhash, pkgType)
-			err := fs.MkdirAll(pkgdir, 0777)
+			urlHash := RepoURLHash(d.Config.Repo)
+			pkgdir := filepath.Join(baseDir, urlHash, pkgType)
 			var pkgFile string
 			if d.Config.Type == Binary {
 				pkgFile = filepath.Join(pkgdir, binaryName(d.Package.Package, d.Package.Version))
 			} else {
 				pkgFile = filepath.Join(pkgdir, fmt.Sprintf("%s_%s.tar.gz", d.Package.Package, d.Package.Version))
-			}
-			if err != nil {
-				fmt.Println("error creating package directory ", pkgdir)
-				fmt.Println("error: ", err)
-				// should this trigger something more impactful? probably since wouldn't download anything
-				return
 			}
 			dl, err := DownloadPackage(fs, d, pkgFile)
 			if err != nil {
@@ -86,7 +98,7 @@ func DownloadPackages(fs afero.Fs, ds []PkgDl, baseDir string) (*PkgMap, error) 
 		}(d, &wg)
 	}
 	wg.Wait()
-	fmt.Println("all packages downloaded")
+	fmt.Printf("all packages downloaded in %s\n\n", time.Since(startTime))
 	return result, nil
 }
 

--- a/cran/download-package.go
+++ b/cran/download-package.go
@@ -38,6 +38,9 @@ func DownloadPackages(fs afero.Fs, ds []PkgDl, baseDir string) (*PkgMap, error) 
 		wg.Add(1)
 		go func(d PkgDl, wg *sync.WaitGroup) {
 			var pkgType string
+			if d.Config.Type == Default {
+				d.Config.Type = DefaultType()
+			}
 			switch d.Config.Type {
 			case Binary:
 				pkgType = "binary"

--- a/cran/repodb.go
+++ b/cran/repodb.go
@@ -88,11 +88,10 @@ func (r *RepoDb) FetchPackages() error {
 		if fi.ModTime().Add(1*time.Hour).Unix() > time.Now().Unix() {
 			// only read if was cached in the last hour
 			return r.Decode(pkgdbFile)
-		} else {
-			err := os.Remove(pkgdbFile)
-			if err != nil {
-				fmt.Println("error removing cache ", pkgdbFile, err)
-			}
+		}
+		err := os.Remove(pkgdbFile)
+		if err != nil {
+			fmt.Println("error removing cache ", pkgdbFile, err)
 		}
 	}
 	for st := range r.Dbs {

--- a/cran/utils.go
+++ b/cran/utils.go
@@ -1,7 +1,9 @@
 package cran
 
 import (
+	"crypto/md5"
 	"fmt"
+	"io"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -71,4 +73,14 @@ func cranBinaryURL() string {
 		fmt.Println("platform not supported for binary detection")
 		return ""
 	}
+}
+
+// RepoURLHash provides a hash of the repoURL
+// given the structure Name-<urlhash>
+func RepoURLHash(r RepoURL) string {
+	h := md5.New()
+	// don't hash everything as still want a reasonable identifier
+	io.WriteString(h, r.URL)
+	urlHash := fmt.Sprintf("%x", h.Sum(nil))
+	return r.Name + "-" + urlHash[:12]
 }

--- a/cran/utils_test.go
+++ b/cran/utils_test.go
@@ -1,0 +1,44 @@
+package cran
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUrlHash(t *testing.T) {
+	assert := assert.New(t)
+
+	var installArgsTests = []struct {
+		in       RepoURL
+		expected string
+	}{
+		{
+			RepoURL{
+				Name: "CRAN",
+				URL:  "https://cran.microsoft.com/snapshot/2018-11-11",
+			},
+			"CRAN-6a482b33cea8",
+		},
+		{
+			RepoURL{
+				Name: "CRAN",
+				URL:  "https://cran.rstudio.com",
+			},
+			"CRAN-739227e5b53e",
+		},
+		{
+			RepoURL{
+				Name: "gh_dev",
+				URL:  "https://metrumresearchgroup.github.io/rpkgs/gh_dev",
+			},
+			"gh_dev-a1f00a415a5e",
+		},
+	}
+	for i, tt := range installArgsTests {
+		actual := RepoURLHash(tt.in)
+		assert.Equal(actual, tt.expected, fmt.Sprintf("test num: %v", i+1))
+
+	}
+}

--- a/rcmd/RunR.go
+++ b/rcmd/RunR.go
@@ -21,8 +21,7 @@ func RunR(
 
 	envVars := configureEnv(rs, lg)
 	cmdArgs := []string{
-		"--no-save",
-		"--no-restore-data",
+		"--vanilla",
 	}
 
 	lg.WithFields(

--- a/rcmd/install.go
+++ b/rcmd/install.go
@@ -155,6 +155,7 @@ func Install(
 	envVars := configureEnv(rs, lg) 
 
 	cmdArgs := []string{
+		"--vanilla",
 		"CMD",
 		"INSTALL",
 	}

--- a/rcmd/install.go
+++ b/rcmd/install.go
@@ -67,7 +67,7 @@ func configureEnv(
 	envVars := os.Environ()
 	envMap := make(map[string]string)
 	for _, ev := range envVars {
-		evs := strings.SplitN(ev, "=", 1)
+		evs := strings.SplitN(ev, "=", 2)
 		if len(evs) > 1 && evs[1] != "" {
 			envMap[evs[0]] = evs[1] 
 		}

--- a/rpackage/rpackage.go
+++ b/rpackage/rpackage.go
@@ -1,0 +1,1 @@
+package rpackage


### PR DESCRIPTION
enforce deeper isolation during R CMDs to keep the pkgr.yml self contained

prevents conflicts against env vars or other settings in user/site level Renv/profiles.

This will likely need more iteration to allow opt-in of certain globally set information.