### PR TITLE
feat: environment variable expansion

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,11 +121,7 @@ func initConfig() {
 	// if cfgFile != "" { // enable ability to specify config file via flag
 	// 	viper.SetConfigFile(cfgFile)
 	// }
-	if viper.GetString("config") == "" {
-		_ = configlib.LoadGlobalConfig("pkgr")
-	} else {
-		_ = configlib.LoadConfigFromPath(viper.GetString("config"))
-	}
+	configlib.LoadConfigFromPath(viper.GetString("config"))
 
 	setGlobals()
 	if viper.GetBool("debug") {

--- a/integration_tests/pkgr-multirepo-source.yml
+++ b/integration_tests/pkgr-multirepo-source.yml
@@ -20,7 +20,7 @@ Packages:
 # any repositories, order matters
 Repos:
   - r_validated: "https://metrumresearchgroup.github.io/r_validated"
-  - CRAN: "https://cran.rstudio.com"
+  - CRAN: "${CRAN_URL}"
 
 Library: "testsets/multirepo"
 


### PR DESCRIPTION
example of use in multirepo-source shows replacing a url with an environment variable

this will also help when using pkgr within matrix builds, such as installing iteratively where a single config file can be used.

This compliments viper's ability to detect environment variables with the prefix `PKGR`

so could still do `PKGR_Library` instead of `Library: path/to/lib`, however viper could not directly support configuration files themselves, where situations such as: `Library: some/path/with/${somevar}` are reasonable.