### PR TITLE
Feat/env

### DIFF
--- a/cmd/experiment.go
+++ b/cmd/experiment.go
@@ -48,13 +48,13 @@ func rExperiment(cmd *cobra.Command, args []string) error {
 	// at least for experimentation for now. If necessary can refactor out the
 	// specifics so could be run here exactly.
 	rs.LibPaths = append(rs.LibPaths, cfg.Library)
-	res, _ := rcmd.RunR(fs, rs, ".libPaths()", "")
+	res, _ := rcmd.RunR(fs, "", rs, ".libPaths()", "")
 	fmt.Println(rp.ScanLines(res))
 	startTime := time.Now()
-	res, _ = rcmd.RunR(fs, rs, "paste0(R.Version()$major,'.',R.Version()$minor)", "")
+	res, _ = rcmd.RunR(fs, "", rs, "paste0(R.Version()$major,'.',R.Version()$minor)", "")
 	fmt.Println(rp.ScanLines(res)[0])
 	fmt.Println(time.Since(startTime))
-	res, err := rcmd.RunR(fs, rs, "stop('bad')", "")
+	res, err := rcmd.RunR(fs, "", rs, "stop('bad')", "")
 	fmt.Println(res)
 	fmt.Println("err: ", err)
 	fmt.Println(rp.ScanLines(res))

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -23,7 +23,6 @@ import (
 	"github.com/metrumresearchgroup/pkgr/cran"
 	"github.com/metrumresearchgroup/pkgr/rcmd"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // installCmd represents the R CMD install command
@@ -67,7 +66,14 @@ func rInstall(cmd *cobra.Command, args []string) error {
 	if nworkers > 2 {
 		nworkers = nworkers - 1
 	}
-	err = rcmd.InstallPackagePlan(fs, ip, dl, pc, ia, rcmd.NewRSettings(), rcmd.ExecSettings{}, nworkers)
+	rs := rcmd.NewRSettings()
+	pkgCustomizations := cfg.Customizations.Packages
+	for n, v := range pkgCustomizations {
+		if v.Env != nil {
+			rs.PkgEnvVars[n] = v.Env
+		}
+	}
+	err = rcmd.InstallPackagePlan(fs, ip, dl, pc, ia, rs, rcmd.ExecSettings{}, nworkers)
 	if err != nil {
 		fmt.Println("failed package install")
 		fmt.Println(err)
@@ -77,7 +83,5 @@ func rInstall(cmd *cobra.Command, args []string) error {
 }
 
 func init() {
-	installCmd.PersistentFlags().String("library", "", "library to install packages to")
-	viper.BindPFlag("library", installCmd.PersistentFlags().Lookup("library"))
 	RootCmd.AddCommand(installCmd)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,6 +20,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var pkg string
+
 // checkCmd represents the R CMD check command
 var runCmd = &cobra.Command{
 	Use:   "run R",
@@ -37,10 +39,17 @@ func rRun(cmd *cobra.Command, args []string) error {
 	// at least for experimentation for now. If necessary can refactor out the
 	// specifics so could be run here exactly.
 	rs.LibPaths = append(rs.LibPaths, cfg.Library)
-	rcmd.StartR(fs, rs, "")
+	pc := cfg.Customizations.Packages
+	for n, v := range pc {
+		if v.Env != nil {
+			rs.PkgEnvVars[n] = v.Env
+		}
+	}
+	rcmd.StartR(fs, pkg, rs, "")
 	return nil
 }
 
 func init() {
+	runCmd.Flags().StringVar(&pkg, "pkg", "", "package environment to set")
 	RootCmd.AddCommand(runCmd)
 }

--- a/configlib/structs.go
+++ b/configlib/structs.go
@@ -3,7 +3,7 @@ package configlib
 // PkgConfig provides information about custom settings during package installation
 type PkgConfig struct {
 	Suggests bool
-	Env      []map[string]string
+	Env      map[string]string
 	Repo     string
 	Type     string
 }

--- a/integration_tests/pkgr-multirepo.yml
+++ b/integration_tests/pkgr-multirepo.yml
@@ -38,7 +38,7 @@ Customizations:
   Packages:
     - data.table:
         Env:
-          - R_MAKEVARS_USER: "~/.R/Makevars_data.table"
+          R_MAKEVARS_USER: "~/.R/Makevars_data.table"
     - mrgsolve:
        Repo: CRAN
        Type: source

--- a/rcmd/Rsettings.go
+++ b/rcmd/Rsettings.go
@@ -8,7 +8,8 @@ import (
 // NewRSettings initializes RSettings
 func NewRSettings() RSettings {
 	return RSettings{
-		EnvVars: make(map[string]string),
+		GlobalEnvVars: make(map[string]string),
+		PkgEnvVars:    make(map[string]map[string]string),
 	}
 }
 

--- a/rcmd/RunR.go
+++ b/rcmd/RunR.go
@@ -12,14 +12,16 @@ import (
 const defaultFailedCode = 1
 const defaultSuccessCode = 0
 
-// StartR launches an interactive R console
+// StartR launches an interactive R console given the same
+// configuration as a specific package.
 func StartR(
 	fs afero.Fs,
+	pkg string,
 	rs RSettings,
 	rdir string, // this should be put into RSettings
 ) error {
 
-	envVars := configureEnv(rs)
+	envVars := configureEnv(rs, pkg)
 	cmdArgs := []string{
 		"--vanilla",
 	}
@@ -58,12 +60,13 @@ func StartR(
 // RunR launches an interactive R console
 func RunR(
 	fs afero.Fs,
+	pkg string,
 	rs RSettings,
 	script string,
 	rdir string, // this should be put into RSettings
 ) ([]byte, error) {
 
-	envVars := configureEnv(rs)
+	envVars := configureEnv(rs, pkg)
 	cmdArgs := []string{
 		"--vanilla",
 		"-e",

--- a/rcmd/RunR.go
+++ b/rcmd/RunR.go
@@ -21,7 +21,7 @@ func StartR(
 	rdir string, // this should be put into RSettings
 ) error {
 
-	envVars := configureEnv(rs, pkg)
+	envVars := configureEnv(os.Environ(), rs, pkg)
 	cmdArgs := []string{
 		"--vanilla",
 	}
@@ -66,7 +66,7 @@ func RunR(
 	rdir string, // this should be put into RSettings
 ) ([]byte, error) {
 
-	envVars := configureEnv(rs, pkg)
+	envVars := configureEnv(os.Environ(), rs, pkg)
 	cmdArgs := []string{
 		"--vanilla",
 		"-e",

--- a/rcmd/configure.go
+++ b/rcmd/configure.go
@@ -47,11 +47,11 @@ func configureEnv(sysEnvVars []string, rs RSettings, pkg string) []string {
 			// in Library/Libpaths in the pkgr configuration
 			// we only want R_LIBS_SITE set to control all relevant library paths for the user to
 			if evs[0] == "R_LIBS_USER" {
-				log.WithField("path", evs[1]).Debug("deleting set R_LIBS_USER")
+				log.WithField("path", evs[1]).Debug("overriding system R_LIBS_USER")
 				continue
 			}
 			if evs[0] == "R_LIBS_SITE" {
-				log.WithField("path", evs[1]).Debug("deleting set R_LIBS_USER")
+				log.WithField("path", evs[1]).Debug("overriding system R_LIBS_USER")
 				continue
 			}
 

--- a/rcmd/configure.go
+++ b/rcmd/configure.go
@@ -8,39 +8,49 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// envVars contains the default environment variables usually from
+// sysEnvVars contains the default environment variables usually from
 // os.Environ()
-func configureEnv(envVars []string, rs RSettings, pkg string) []string {
+func configureEnv(sysEnvVars []string, rs RSettings, pkg string) []string {
 	envMap := make(map[string]string)
-	for _, ev := range envVars {
+	envVars := []string{}
+	envOrder := []string{}
+
+	// system env vars generally
+	for _, ev := range sysEnvVars {
 		evs := strings.SplitN(ev, "=", 2)
 		if len(evs) > 1 && evs[1] != "" {
+
+			// we don't want to track the order of these anyway since they should take priority in the end
+			// R_LIBS_USER takes precidence over R_LIBS_SITE
+			// so will cause the loading characteristics to
+			// not be representative of the hierarchy specified
+			// in Library/Libpaths in the pkgr configuration
+			// we only want R_LIBS_SITE set to control all relevant library paths for the user to
+			if evs[0] == "R_LIBS_USER" {
+				log.WithField("path", evs[1]).Debug("deleting set R_LIBS_USER")
+				continue
+			}
+			if evs[0] == "R_LIBS_SITE" {
+				log.WithField("path", evs[1]).Debug("deleting set R_LIBS_USER")
+				continue
+			}
 			envMap[evs[0]] = evs[1]
+			envOrder = append(envOrder, evs[0])
 		}
 	}
-	rlu, exists := envMap["R_LIBS_USER"]
-	if exists {
-		// R_LIBS_USER takes precidence over R_LIBS_SITE
-		// so will cause the loading characteristics to
-		// not be representative of the hierarchy specified
-		// in Library/Libpaths in the pkgr configuration
-		delete(envMap, "R_LIBS_USER")
-		log.WithField("path", rlu).Debug("deleting set R_LIBS_USER")
-	}
-	envVars = []string{}
+
+	// TODO: determine if using globalenvvars as a map could cause subtle bug given ordering precedence
 	for k, v := range rs.GlobalEnvVars {
 		envMap[k] = v
 	}
 
 	ok, lp := rs.LibPathsEnv()
 	if ok {
-		// if LibPaths set, lets drop R_LIBS_SITE set as an ENV and instead
-		// add the generated R_LIBS_SITE from LibPathsEnv
-		delete(envMap, "R_LIBS_SITE")
 		envVars = append(envVars, lp)
 	}
-	for k, v := range envMap {
-		envVars = append(envVars, fmt.Sprintf("%s=%s", k, v))
+	for _, ev := range envOrder {
+		val := envMap[ev]
+		envVars = append(envVars, fmt.Sprintf("%s=%s", ev, val))
 	}
 	pkgEnv, hasCustomEnv := rs.PkgEnvVars[pkg]
 	if hasCustomEnv {
@@ -56,9 +66,6 @@ func configureEnv(envVars []string, rs RSettings, pkg string) []string {
 			"package": pkg,
 		}).Trace("Custom Environment Variables")
 	}
-	// double down on overwriting any specification of user customization
-	// and set R_LIBS_SITE to the same as the user
-	envVars = append(envVars, strings.Replace(lp, "R_LIBS_SITE", "R_LIBS_USER", 1))
 
 	return envVars
 }

--- a/rcmd/configure.go
+++ b/rcmd/configure.go
@@ -1,0 +1,64 @@
+package rcmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
+)
+
+// envVars contains the default environment variables usually from
+// os.Environ()
+func configureEnv(envVars []string, rs RSettings, pkg string) []string {
+	envMap := make(map[string]string)
+	for _, ev := range envVars {
+		evs := strings.SplitN(ev, "=", 2)
+		if len(evs) > 1 && evs[1] != "" {
+			envMap[evs[0]] = evs[1]
+		}
+	}
+	rlu, exists := envMap["R_LIBS_USER"]
+	if exists {
+		// R_LIBS_USER takes precidence over R_LIBS_SITE
+		// so will cause the loading characteristics to
+		// not be representative of the hierarchy specified
+		// in Library/Libpaths in the pkgr configuration
+		delete(envMap, "R_LIBS_USER")
+		log.WithField("path", rlu).Debug("deleting set R_LIBS_USER")
+	}
+	envVars = []string{}
+	for k, v := range rs.GlobalEnvVars {
+		envMap[k] = v
+	}
+
+	ok, lp := rs.LibPathsEnv()
+	if ok {
+		// if LibPaths set, lets drop R_LIBS_SITE set as an ENV and instead
+		// add the generated R_LIBS_SITE from LibPathsEnv
+		delete(envMap, "R_LIBS_SITE")
+		envVars = append(envVars, lp)
+	}
+	for k, v := range envMap {
+		envVars = append(envVars, fmt.Sprintf("%s=%s", k, v))
+	}
+	pkgEnv, hasCustomEnv := rs.PkgEnvVars[pkg]
+	if hasCustomEnv {
+		// not sure if this is needed when logging maps but for simple json want a single string
+		// so will also collect in a separate set of envs and log as a single combined string
+		var pkgEnvForLog []string
+		for k, v := range pkgEnv {
+			envVars = append(envVars, fmt.Sprintf("%s=%s", k, v))
+			pkgEnvForLog = append(pkgEnvForLog, fmt.Sprintf("%s=%s", k, v))
+		}
+		log.WithFields(logrus.Fields{
+			"envs":    pkgEnvForLog,
+			"package": pkg,
+		}).Trace("Custom Environment Variables")
+	}
+	// double down on overwriting any specification of user customization
+	// and set R_LIBS_SITE to the same as the user
+	envVars = append(envVars, strings.Replace(lp, "R_LIBS_SITE", "R_LIBS_USER", 1))
+
+	return envVars
+}

--- a/rcmd/configure_test.go
+++ b/rcmd/configure_test.go
@@ -1,0 +1,33 @@
+package rcmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigureArgs(t *testing.T) {
+	assert := assert.New(t)
+
+	var installArgsTests = []struct {
+		in       string
+		expected []string
+	}{
+		{
+			"",
+			[]string{"R_LIBS_SITE=path/to/install/lib", "R_LIBS_USER=path/to/install/lib"},
+		},
+		{
+			"dplyr",
+			[]string{"R_LIBS_SITE=path/to/install/lib", "R_LIBS_USER=path/to/install/lib"},
+		},
+	}
+	defaultRS := RSettings{}
+	defaultRS.LibPaths = []string{"path/to/install/lib"}
+	for i, tt := range installArgsTests {
+		actual := configureEnv([]string{}, defaultRS, tt.in)
+		assert.Equal(actual, tt.expected, fmt.Sprintf("test num: %v", i+1))
+
+	}
+}

--- a/rcmd/configure_test.go
+++ b/rcmd/configure_test.go
@@ -25,60 +25,60 @@ func TestConfigureArgs(t *testing.T) {
 			"minimal",
 			"",
 			[]string{},
-			[]string{"R_LIBS_SITE=path/to/install/lib", "R_LIBS_USER=path/to/install/lib"},
+			[]string{"R_LIBS_SITE=path/to/install/lib"},
 		},
 		{
 			"non-impactful system env set",
 			"",
 			[]string{"MISC_ENV=foo", "MISC2=bar"},
-			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "MISC_ENV=foo", "R_LIBS_USER=path/to/install/lib"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC_ENV=foo", "MISC2=bar"},
 		},
 		{
 			"non-impactful system env set with known package",
 			"dplyr",
 			[]string{"MISC_ENV=foo", "MISC2=bar"},
-			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "MISC_ENV=foo", "R_LIBS_USER=path/to/install/lib"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC_ENV=foo", "MISC2=bar"},
 		},
 		{
 			"R_LIBS_SITE env set",
 			"",
 			[]string{"R_LIBS_SITE=original/path", "MISC2=bar"},
-			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "R_LIBS_USER=path/to/install/lib"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar"},
 		},
 		{
 			"R_LIBS_SITE env set with known package",
 			"dplyr",
 			[]string{"R_LIBS_SITE=original/path", "MISC2=bar"},
-			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "R_LIBS_USER=path/to/install/lib"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar"},
 		},
 		{
 			"R_LIBS_USER env set",
 			"",
 			[]string{"R_LIBS_USER=original/path", "MISC2=bar"},
-			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "R_LIBS_USER=path/to/install/lib"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar"},
 		},
 		{
 			"R_LIBS_USER env set with known package",
 			"dplyr",
 			[]string{"R_LIBS_USER=original/path", "MISC2=bar"},
-			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "R_LIBS_USER=path/to/install/lib"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar"},
 		},
 		{
 			"R_LIBS_SITE and R_LIBS_USER env set",
 			"",
 			[]string{"R_LIBS_USER=original/path", "R_LIBS_SITE=original/site/path", "MISC2=bar"},
-			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "R_LIBS_USER=path/to/install/lib"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar"},
 		},
 		{
 			"R_LIBS_SITE and R_LIBS_USER env set",
 			"dplyr",
 			[]string{"R_LIBS_USER=original/path", "R_LIBS_SITE=original/site/path", "MISC2=bar"},
-			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "R_LIBS_USER=path/to/install/lib"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar"},
 		},
 	}
 	for i, tt := range installArgsTests {
 		actual := configureEnv(tt.sysEnv, defaultRS, tt.in)
-		assert.Equal(actual, tt.expected, fmt.Sprintf("%s, test num: %v", tt.context, i+1))
+		assert.Equal(tt.expected, actual, fmt.Sprintf("%s, test num: %v", tt.context, i+1))
 	}
 
 }

--- a/rcmd/configure_test.go
+++ b/rcmd/configure_test.go
@@ -13,7 +13,7 @@ func TestConfigureArgs(t *testing.T) {
 	defaultRS := NewRSettings()
 	// there should always be at least one libpath
 	defaultRS.LibPaths = []string{"path/to/install/lib"}
-
+	defaultRS.PkgEnvVars["dplyr"] = map[string]string{"DPLYR_ENV": "true"}
 	var installArgsTests = []struct {
 		context string
 		in      string
@@ -37,7 +37,19 @@ func TestConfigureArgs(t *testing.T) {
 			"non-impactful system env set with known package",
 			"dplyr",
 			[]string{"MISC_ENV=foo", "MISC2=bar"},
-			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC_ENV=foo", "MISC2=bar"},
+			[]string{"DPLYR_ENV=true", "R_LIBS_SITE=path/to/install/lib", "MISC_ENV=foo", "MISC2=bar"},
+		},
+		{
+			"impactful system env set on separate package",
+			"",
+			[]string{"MISC_ENV=foo", "MISC2=bar", "DPLYR_ENV=false"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC_ENV=foo", "MISC2=bar", "DPLYR_ENV=false"},
+		},
+		{
+			"impactful system env set with known package",
+			"dplyr",
+			[]string{"MISC_ENV=foo", "MISC2=bar", "DPLYR_ENV=false"},
+			[]string{"DPLYR_ENV=true", "R_LIBS_SITE=path/to/install/lib", "MISC_ENV=foo", "MISC2=bar"},
 		},
 		{
 			"R_LIBS_SITE env set",
@@ -49,7 +61,7 @@ func TestConfigureArgs(t *testing.T) {
 			"R_LIBS_SITE env set with known package",
 			"dplyr",
 			[]string{"R_LIBS_SITE=original/path", "MISC2=bar"},
-			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar"},
+			[]string{"DPLYR_ENV=true", "R_LIBS_SITE=path/to/install/lib", "MISC2=bar"},
 		},
 		{
 			"R_LIBS_USER env set",
@@ -61,7 +73,7 @@ func TestConfigureArgs(t *testing.T) {
 			"R_LIBS_USER env set with known package",
 			"dplyr",
 			[]string{"R_LIBS_USER=original/path", "MISC2=bar"},
-			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar"},
+			[]string{"DPLYR_ENV=true", "R_LIBS_SITE=path/to/install/lib", "MISC2=bar"},
 		},
 		{
 			"R_LIBS_SITE and R_LIBS_USER env set",
@@ -73,7 +85,7 @@ func TestConfigureArgs(t *testing.T) {
 			"R_LIBS_SITE and R_LIBS_USER env set",
 			"dplyr",
 			[]string{"R_LIBS_USER=original/path", "R_LIBS_SITE=original/site/path", "MISC2=bar"},
-			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar"},
+			[]string{"DPLYR_ENV=true", "R_LIBS_SITE=path/to/install/lib", "MISC2=bar"},
 		},
 	}
 	for i, tt := range installArgsTests {

--- a/rcmd/configure_test.go
+++ b/rcmd/configure_test.go
@@ -10,24 +10,75 @@ import (
 func TestConfigureArgs(t *testing.T) {
 	assert := assert.New(t)
 
+	defaultRS := NewRSettings()
+	// there should always be at least one libpath
+	defaultRS.LibPaths = []string{"path/to/install/lib"}
+
 	var installArgsTests = []struct {
-		in       string
+		context string
+		in      string
+		// mocked system environment variables per os.Environ()
+		sysEnv   []string
 		expected []string
 	}{
 		{
+			"minimal",
 			"",
+			[]string{},
 			[]string{"R_LIBS_SITE=path/to/install/lib", "R_LIBS_USER=path/to/install/lib"},
 		},
 		{
+			"non-impactful system env set",
+			"",
+			[]string{"MISC_ENV=foo", "MISC2=bar"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "MISC_ENV=foo", "R_LIBS_USER=path/to/install/lib"},
+		},
+		{
+			"non-impactful system env set with known package",
 			"dplyr",
-			[]string{"R_LIBS_SITE=path/to/install/lib", "R_LIBS_USER=path/to/install/lib"},
+			[]string{"MISC_ENV=foo", "MISC2=bar"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "MISC_ENV=foo", "R_LIBS_USER=path/to/install/lib"},
+		},
+		{
+			"R_LIBS_SITE env set",
+			"",
+			[]string{"R_LIBS_SITE=original/path", "MISC2=bar"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "R_LIBS_USER=path/to/install/lib"},
+		},
+		{
+			"R_LIBS_SITE env set with known package",
+			"dplyr",
+			[]string{"R_LIBS_SITE=original/path", "MISC2=bar"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "R_LIBS_USER=path/to/install/lib"},
+		},
+		{
+			"R_LIBS_USER env set",
+			"",
+			[]string{"R_LIBS_USER=original/path", "MISC2=bar"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "R_LIBS_USER=path/to/install/lib"},
+		},
+		{
+			"R_LIBS_USER env set with known package",
+			"dplyr",
+			[]string{"R_LIBS_USER=original/path", "MISC2=bar"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "R_LIBS_USER=path/to/install/lib"},
+		},
+		{
+			"R_LIBS_SITE and R_LIBS_USER env set",
+			"",
+			[]string{"R_LIBS_USER=original/path", "R_LIBS_SITE=original/site/path", "MISC2=bar"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "R_LIBS_USER=path/to/install/lib"},
+		},
+		{
+			"R_LIBS_SITE and R_LIBS_USER env set",
+			"dplyr",
+			[]string{"R_LIBS_USER=original/path", "R_LIBS_SITE=original/site/path", "MISC2=bar"},
+			[]string{"R_LIBS_SITE=path/to/install/lib", "MISC2=bar", "R_LIBS_USER=path/to/install/lib"},
 		},
 	}
-	defaultRS := RSettings{}
-	defaultRS.LibPaths = []string{"path/to/install/lib"}
 	for i, tt := range installArgsTests {
-		actual := configureEnv([]string{}, defaultRS, tt.in)
-		assert.Equal(actual, tt.expected, fmt.Sprintf("test num: %v", i+1))
-
+		actual := configureEnv(tt.sysEnv, defaultRS, tt.in)
+		assert.Equal(actual, tt.expected, fmt.Sprintf("%s, test num: %v", tt.context, i+1))
 	}
+
 }

--- a/rcmd/install.go
+++ b/rcmd/install.go
@@ -62,60 +62,6 @@ func (i InstallArgs) CliArgs() []string {
 	return args
 }
 
-func configureEnv(rs RSettings, pkg string) []string {
-	envVars := os.Environ()
-	envMap := make(map[string]string)
-	for _, ev := range envVars {
-		evs := strings.SplitN(ev, "=", 2)
-		if len(evs) > 1 && evs[1] != "" {
-			envMap[evs[0]] = evs[1]
-		}
-	}
-	rlu, exists := envMap["R_LIBS_USER"]
-	if exists {
-		// R_LIBS_USER takes precidence over R_LIBS_SITE
-		// so will cause the loading characteristics to
-		// not be representative of the hierarchy specified
-		// in Library/Libpaths in the pkgr configuration
-		delete(envMap, "R_LIBS_USER")
-		log.WithField("path", rlu).Debug("deleting set R_LIBS_USER")
-	}
-	envVars = []string{}
-	for k, v := range rs.GlobalEnvVars {
-		envMap[k] = v
-	}
-
-	ok, lp := rs.LibPathsEnv()
-	if ok {
-		// if LibPaths set, lets drop R_LIBS_SITE set as an ENV and instead
-		// add the generated R_LIBS_SITE from LibPathsEnv
-		delete(envMap, "R_LIBS_SITE")
-		envVars = append(envVars, lp)
-	}
-	for k, v := range envMap {
-		envVars = append(envVars, fmt.Sprintf("%s=%s", k, v))
-	}
-	pkgEnv, hasCustomEnv := rs.PkgEnvVars[pkg]
-	if hasCustomEnv {
-		// not sure if this is needed when logging maps but for simple json want a single string
-		// so will also collect in a separate set of envs and log as a single combined string
-		var pkgEnvForLog []string
-		for k, v := range pkgEnv {
-			envVars = append(envVars, fmt.Sprintf("%s=%s", k, v))
-			pkgEnvForLog = append(pkgEnvForLog, fmt.Sprintf("%s=%s", k, v))
-		}
-		log.WithFields(logrus.Fields{
-			"envs":    pkgEnvForLog,
-			"package": pkg,
-		}).Trace("Custom Environment Variables")
-	}
-	// double down on overwriting any specification of user customization
-	// and set R_LIBS_SITE to the same as the user
-	envVars = append(envVars, strings.Replace(lp, "R_LIBS_SITE", "R_LIBS_USER", 1))
-
-	return envVars
-}
-
 // Install installs a given tarball
 // exit code 0 - success, 1 - error
 func Install(
@@ -165,7 +111,7 @@ func Install(
 		}, err
 	}
 
-	envVars := configureEnv(rs, pkg)
+	envVars := configureEnv(os.Environ(), rs, pkg)
 
 	cmdArgs := []string{
 		"--vanilla",

--- a/rcmd/install_test.go
+++ b/rcmd/install_test.go
@@ -33,7 +33,7 @@ func TestInstallArgs(t *testing.T) {
 	}
 	for i, tt := range installArgsTests {
 		actual := tt.in.CliArgs()
-		assert.Equal(actual, tt.expected, fmt.Sprintf("test num: %v", i+1))
+		assert.Equal(tt.expected, actual, fmt.Sprintf("test num: %v", i+1))
 
 	}
 }

--- a/rcmd/structs.go
+++ b/rcmd/structs.go
@@ -25,10 +25,11 @@ type RVersion struct {
 
 // RSettings controls settings related to managing libraries
 type RSettings struct {
-	Version  RVersion          `json:"r_version,omitempty"`
-	LibPaths []string          `json:"lib_paths,omitempty"`
-	Rpath    string            `json:"rpath,omitempty"`
-	EnvVars  map[string]string `json:"env_vars,omitempty"`
+	Version       RVersion                     `json:"r_version,omitempty"`
+	LibPaths      []string                     `json:"lib_paths,omitempty"`
+	Rpath         string                       `json:"rpath,omitempty"`
+	GlobalEnvVars map[string]string            `json:"global_env_vars,omitempty"`
+	PkgEnvVars    map[string]map[string]string `json:"pkg_env_vars,omitempty"`
 }
 
 // InstallArgs represents the installation arguments R CMD INSTALL can consume


### PR DESCRIPTION
add the capability to set environment variables during installation of packages. 

The overall internal representation is to now store two sets of env variables - global ones that should be applied to every package during install, as well as local ones per package.