### PR TITLE
Fix/rpath

### DIFF
--- a/cmd/cleanPkgdb.go
+++ b/cmd/cleanPkgdb.go
@@ -17,8 +17,10 @@ package cmd
 import (
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/metrumresearchgroup/pkgr/configlib"
+
 	"github.com/metrumresearchgroup/pkgr/rcmd"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -66,7 +68,7 @@ func cleanPackageDatabases(pkgdbs string) error {
 	}
 
 	totalPackageDbsProvided := len(pkgdbsToClear)
-	totalPackageDbsDeleted := removePackageDatabases(pkgdbsToClear)
+	totalPackageDbsDeleted := removePackageDatabases(pkgdbsToClear, cfg)
 
 	log.WithFields(log.Fields{
 		"Packages specified": totalPackageDbsProvided,
@@ -76,11 +78,11 @@ func cleanPackageDatabases(pkgdbs string) error {
 	return nil
 }
 
-func removePackageDatabases(pkgdbsToClear []string) error {
+func removePackageDatabases(pkgdbsToClear []string, cfg configlib.PkgrConfig) error {
 	var err error
 	var lastErr error
 
-	rs := rcmd.NewRSettings()
+	rs := rcmd.NewRSettings(cfg.RPath)
 	rVersion := rcmd.GetRVersion(&rs)
 
 	packageDatabase, _ := planInstall(rVersion)

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -21,17 +21,17 @@ import (
 	"github.com/spf13/viper"
 )
 
-// showCmd shows information about internal settings
-var showCmd = &cobra.Command{
-	Use:   "show",
-	Short: "show with the cli",
+// debugCmd debugs information about internal settings
+var debugCmd = &cobra.Command{
+	Use:   "debug",
+	Short: "debug with the cli",
 	Long: `
-	show internal settings
+	debug internal settings
  `,
-	RunE: rShow,
+	RunE: rDebug,
 }
 
-func rShow(cmd *cobra.Command, args []string) error {
+func rDebug(cmd *cobra.Command, args []string) error {
 
 	//AppFs := afero.NewOsFs()
 	// can use this to redirect log output
@@ -44,14 +44,15 @@ func rShow(cmd *cobra.Command, args []string) error {
 	as := viper.AllSettings()
 	fmt.Println(as)
 	fmt.Println("subs:")
-	fmt.Println(viper.Sub("Customizations"))
-	fmt.Println(viper.Sub("Customizations").AllSettings()["packages"])
-	fmt.Println(viper.Sub("Customizations").AllSettings()["repos"])
+	if viper.Sub("Customizations") != nil {
+		fmt.Println(viper.Sub("Customizations").AllSettings()["packages"])
+		fmt.Println(viper.Sub("Customizations").AllSettings()["repos"])
+	}
 	fmt.Println("------config-------")
 	prettyPrint(cfg)
 	return nil
 }
 
 func init() {
-	RootCmd.AddCommand(showCmd)
+	RootCmd.AddCommand(debugCmd)
 }

--- a/cmd/experiment.go
+++ b/cmd/experiment.go
@@ -43,7 +43,7 @@ func rExperiment(cmd *cobra.Command, args []string) error {
 	// 	log.Fatalf("error opening file: %v", err)
 	// }
 	// defer f.Close()
-	rs := rcmd.NewRSettings()
+	rs := rcmd.NewRSettings(cfg.RPath)
 	// installation through binary doesn't do this exactly, but its pretty close
 	// at least for experimentation for now. If necessary can refactor out the
 	// specifics so could be run here exactly.

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/metrumresearchgroup/pkgr/logger"
 
 	"github.com/metrumresearchgroup/pkgr/gpsr"
@@ -57,7 +58,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 		// this should suppress all logging from the planning
 		logger.SetLogLevel("fatal")
 	}
-	rs := rcmd.NewRSettings()
+	rs := rcmd.NewRSettings(cfg.RPath)
 	rVersion := rcmd.GetRVersion(&rs)
 	_, ip := planInstall(rVersion)
 	if showDeps {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/metrumresearchgroup/pkgr/cran"
 	"github.com/metrumresearchgroup/pkgr/logger"
-	log "github.com/sirupsen/logrus"
 	"github.com/metrumresearchgroup/pkgr/rcmd"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +46,7 @@ func rInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	startTime := time.Now()
-	rs := rcmd.NewRSettings()
+	rs := rcmd.NewRSettings(cfg.RPath)
 	rVersion := rcmd.GetRVersion(&rs)
 	log.Infoln("R Version " + rVersion.ToFullString())
 	cdb, ip := planInstall(rVersion)

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -43,7 +43,7 @@ var planCmd = &cobra.Command{
 
 func plan(cmd *cobra.Command, args []string) error {
 	log.Infof("Installation would launch %v workers\n", getWorkerCount())
-	rs := rcmd.NewRSettings()
+	rs := rcmd.NewRSettings(cfg.RPath)
 	rVersion := rcmd.GetRVersion(&rs)
 	log.Infoln("R Version " + rVersion.ToFullString())
 	_, ip := planInstall(rVersion)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -34,7 +34,7 @@ var runCmd = &cobra.Command{
 
 func rRun(cmd *cobra.Command, args []string) error {
 
-	rs := rcmd.NewRSettings()
+	rs := rcmd.NewRSettings(cfg.RPath)
 	// installation through binary doesn't do this exactly, but its pretty close
 	// at least for experimentation for now. If necessary can refactor out the
 	// specifics so could be run here exactly.

--- a/integration_tests/custom_rpath/pkgr.yml
+++ b/integration_tests/custom_rpath/pkgr.yml
@@ -1,0 +1,12 @@
+Version: 1
+# top level packages
+Packages:
+  - R6
+  - pillar
+
+RPath: /usr/local/bin/R
+# any repositories, order matters
+Repos:
+  - CRAN: "https://cran.rstudio.com"
+
+Library: "test-library"

--- a/rcmd/RSettings_integration_test.go
+++ b/rcmd/RSettings_integration_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestRVersionExecution(t *testing.T) {
 	assert := assert.New(t)
-	rs := NewRSettings()
+	rs := NewRSettings("")
 	// this test expects a machine with R 3.5.2 available on the default System Path
 	// TODO: refactor to make more generalized or mock
 	expected := cran.RVersion{3, 5, 2}

--- a/rcmd/Rsettings.go
+++ b/rcmd/Rsettings.go
@@ -12,17 +12,17 @@ import (
 )
 
 // NewRSettings initializes RSettings
-func NewRSettings() RSettings {
+func NewRSettings(rPath string) RSettings {
 	return RSettings{
 		GlobalEnvVars: make(map[string]string),
 		PkgEnvVars:    make(map[string]map[string]string),
+		Rpath:         rPath,
 	}
 }
 
 // R provides a cleaned path to the R executable
 func (rs RSettings) R() string {
-	rpath := rs.Rpath
-	if rpath == "" {
+	if rs.Rpath == "" {
 		return ("R")
 	}
 	// TODO: check if this could have problems with trailing slash on windows
@@ -30,7 +30,7 @@ func (rs RSettings) R() string {
 
 	// Need to trim trailing slash as will form the R CMD syntax
 	// eg /path/to/R CMD, so can't have /path/to/R/ CMD
-	return strings.TrimSuffix(rpath, "/")
+	return strings.TrimSuffix(rs.Rpath, "/")
 }
 
 // GetRVersion returns the R version as set in RSettings

--- a/rcmd/configure_test.go
+++ b/rcmd/configure_test.go
@@ -10,7 +10,7 @@ import (
 func TestConfigureArgs(t *testing.T) {
 	assert := assert.New(t)
 
-	defaultRS := NewRSettings()
+	defaultRS := NewRSettings("")
 	// there should always be at least one libpath
 	defaultRS.LibPaths = []string{"path/to/install/lib"}
 	defaultRS.PkgEnvVars["dplyr"] = map[string]string{"DPLYR_ENV": "true"}


### PR DESCRIPTION
in response to #65 this fixes setting non-default R paths as for the execution of R. 

Primarily focused on environments with multiple versions of R present