### PR TITLE
NOMERGE: Prototype/packrat lock reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ Cache: "path/to/global/cache"
 
 # can log the actions and outcomes to a file for debugging and auditing
 Logging:
-  File: pkgr-install.log
+  all: pkgr-log.log
+  install: install-only-log.log
+  overwrite: true
 
 Customizations:
   - devtools:
@@ -141,7 +143,7 @@ For everything else, the default install behavior will stay in effect.
 
 For a third example, here is a configuration that also pulls from bioconductor:
 
-```
+```yaml
 Version: 1
 # top level packages
 Packages:
@@ -173,7 +175,9 @@ Library: pkgs
 
 Cache: pkgcache
 Logging:
-  File: pkgr-install.log
+  all: pkgr-log.log
+  install: install-only-log.log
+  overwrite: true
 ```
 
 # Pkgr and [Packrat](https://rstudio.github.io/packrat/)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -38,11 +38,11 @@ var installCmd = &cobra.Command{
 
 func rInstall(cmd *cobra.Command, args []string) error {
 
-	//Init install-specific log, if one has been set. This overwrites the default log.
+	logger.AddLogFile(cfg.Logging.All, cfg.Logging.Overwrite)
+
+	//Init install-specific log, if one has been set.
 	if cfg.Logging.Install != "" {
 		logger.AddLogFile(cfg.Logging.Install, cfg.Logging.Overwrite)
-	} else {
-		logger.AddLogFile(cfg.Logging.All, cfg.Logging.Overwrite)
 	}
 
 	startTime := time.Now()

--- a/configlib/structs.go
+++ b/configlib/structs.go
@@ -41,4 +41,5 @@ type PkgrConfig struct {
 	RPath          string
 	Cache          string
 	Logging        LogConfig
+	PackratDir 	   string
 }

--- a/cran/pkgdb.go
+++ b/cran/pkgdb.go
@@ -10,9 +10,9 @@ import (
 	"github.com/metrumresearchgroup/pkgr/desc"
 )
 
-// NewPkgDb returns a new package database
-func NewPkgDb(urls []RepoURL, dst SourceType, cfgdb *InstallConfig, rv RVersion) (*PkgDb, error) {
-	db := PkgDb{
+// NewPkgNexus returns a new package database
+func NewPkgNexus(urls []RepoURL, dst SourceType, cfgdb *InstallConfig, rv RVersion) (*PkgNexus, error) {
+	db := PkgNexus{
 		Config:            cfgdb,
 		DefaultSourceType: dst,
 	}
@@ -53,7 +53,7 @@ func NewPkgDb(urls []RepoURL, dst SourceType, cfgdb *InstallConfig, rv RVersion)
 
 // SetPackageRepo sets a package repository so querying the package will
 // pull from that repo
-func (p *PkgDb) SetPackageRepo(pkg string, repo string) error {
+func (p *PkgNexus) SetPackageRepo(pkg string, repo string) error {
 	for _, r := range p.Db {
 		if r.Repo.Name == repo {
 			cfg := p.Config.Packages[pkg]
@@ -66,7 +66,7 @@ func (p *PkgDb) SetPackageRepo(pkg string, repo string) error {
 }
 
 // SetPackageType sets the package type (source/binary) for installation
-func (p *PkgDb) SetPackageType(pkg string, t string) error {
+func (p *PkgNexus) SetPackageType(pkg string, t string) error {
 	cfg := p.Config.Packages[pkg]
 	if strings.EqualFold(t, "source") {
 		cfg.Type = Source
@@ -107,7 +107,7 @@ func isCorrectRepo(pkg string, r RepoURL, cfg map[string]PkgConfig) bool {
 }
 
 // GetPackage gets a package from the package database, returning the first match
-func (p *PkgDb) GetPackage(pkg string) (desc.Desc, PkgConfig, bool) {
+func (p *PkgNexus) GetPackage(pkg string) (desc.Desc, PkgConfig, bool) {
 	cfg, exists := p.Config.Packages[pkg]
 	st := p.DefaultSourceType
 	if exists && cfg.Type != Default {
@@ -130,7 +130,7 @@ func (p *PkgDb) GetPackage(pkg string) (desc.Desc, PkgConfig, bool) {
 }
 
 // GetPackageFromRepo gets a package from a repo in the package database
-func (p *PkgDb) GetPackageFromRepo(pkg string, repo string) (desc.Desc, PkgConfig, bool) {
+func (p *PkgNexus) GetPackageFromRepo(pkg string, repo string) (desc.Desc, PkgConfig, bool) {
 	st := p.Config.Packages[pkg].Type
 	for _, db := range p.Db {
 		if repo != "" && db.Repo.Name != repo {
@@ -145,7 +145,7 @@ func (p *PkgDb) GetPackageFromRepo(pkg string, repo string) (desc.Desc, PkgConfi
 
 // GetPackages returns all packages and the repo that they
 // will be acquired from, as well as any missing packages
-func (p *PkgDb) GetPackages(pkgs []string) AvailablePkgs {
+func (p *PkgNexus) GetPackages(pkgs []string) AvailablePkgs {
 	ap := AvailablePkgs{}
 	for _, pkg := range pkgs {
 		pd, cfg, found := p.GetPackage(pkg)
@@ -163,7 +163,7 @@ func (p *PkgDb) GetPackages(pkgs []string) AvailablePkgs {
 // CheckAllAvailable returns whether all requested packages
 // are available in the package database. It is a simple wrapper
 // around GetPackages
-func (p *PkgDb) CheckAllAvailable(pkgs []string) bool {
+func (p *PkgNexus) CheckAllAvailable(pkgs []string) bool {
 	ap := p.GetPackages(pkgs)
 	if len(ap.Missing) > 0 {
 		return false
@@ -172,7 +172,7 @@ func (p *PkgDb) CheckAllAvailable(pkgs []string) bool {
 }
 
 // GetAllPkgsByName returns all packages in the database
-func (p *PkgDb) GetAllPkgsByName() []string {
+func (p *PkgNexus) GetAllPkgsByName() []string {
 	// use map so will remove duplicate packages
 	pkgMap := make(map[string]bool)
 	for _, db := range p.Db {

--- a/cran/structs.go
+++ b/cran/structs.go
@@ -40,8 +40,8 @@ type PkgConfig struct {
 	Type SourceType
 }
 
-// PkgDb represents a package database
-type PkgDb struct {
+// PkgNexus represents a sort of phone book of all available repositories and packages in those repositories
+type PkgNexus struct {
 	Db                []*RepoDb
 	Config            *InstallConfig
 	DefaultSourceType SourceType

--- a/gpsr/helpers.go
+++ b/gpsr/helpers.go
@@ -10,7 +10,7 @@ func isDefaultPackage(pkg string) bool {
 	return exists
 }
 
-func appendToGraph(m Graph, d desc.Desc, ids InstallDeps, pkgdb *cran.PkgDb) {
+func appendToGraph(m Graph, d desc.Desc, ids InstallDeps, pkgdb *cran.PkgNexus) {
 	var reqs []string
 	id, exists := ids.Deps[d.Package]
 	if !exists {

--- a/gpsr/solution.go
+++ b/gpsr/solution.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ResolveInstallationReqs resolves all the installation requirements
-func ResolveInstallationReqs(pkgs []string, ids InstallDeps, pkgdb *cran.PkgDb) (InstallPlan, error) {
+func ResolveInstallationReqs(pkgs []string, ids InstallDeps, pkgdb *cran.PkgNexus) (InstallPlan, error) {
 	workingGraph := NewGraph()
 	defaultids := NewDefaultInstallDeps()
 	depDb := make(map[string][]string)

--- a/integration_tests/packrat-lock/.gitignore
+++ b/integration_tests/packrat-lock/.gitignore
@@ -1,0 +1,1 @@
+packrat/*

--- a/integration_tests/packrat-lock/pkgr.yml
+++ b/integration_tests/packrat-lock/pkgr.yml
@@ -1,0 +1,29 @@
+Version: 1
+# top level packages
+Packages:
+  - data.table
+
+Suggests: true
+
+# any repositories, order matters
+Repos:
+  - r_validated: "https://metrumresearchgroup.github.io/r_validated"
+  - CRAN: "https://cran.rstudio.com"
+
+Library: "test-library"
+
+PackratDir: "packrat"
+
+Logging:
+  all: alllog.log
+
+# customizations are package specific settings
+# for example, we can use a custom makevar file for data.table
+# by leveraging the R_MAKEVARS_USER to point to a separate makevar
+# each package gets installed in its own process so any env variables
+# or settings will only matter for it
+Customizations:
+  Packages:
+    - data.table:
+       Env:
+         - R_MAKEVARS_USER: "~/.R/Makevars_data.table"


### PR DESCRIPTION
I keep running into problems with my environment on another PC, and I thought it would be nice to have pkgr set up there so can easily take care of reinstalls after I delete folders etc. etc. However, the environment uses Packrat, so I decided to hack together something that would let pkgr read the packages from lockfiles.

I'm creating this pull request mostly for informational/discussion purposes. I timeboxed the effort here somewhat hard, but since I have something vaguely working, I wanted to document the limitations.

## What this can do:
* Parse package information from Packrat lockfiles and organize it into a pkgr-friendly data structure.
* Add packages listed in a packrat lockfile to the run-time configuration of pkgr. In other words, when run with the PackratDir config option set to something, pkgr will treat packages in the lockfile as if they were listed under the "Packages" section of the pkgr.yml file with no customizations.

## Known limitations
* Though I parse all of the information from package stanzas, I only use the package names. This means that package versions and sources are not maintained.
* I do not parse repository information from the lockfile, though I think this would be easy to do. For now, one needs to manually set the repos in pkgr.yml equal to those referenced by packrat.
* I do not do anything to automatically set the install library to the packrat installation directory. This also must be manually done. 
* I'm not doing anything at the moment to account for duplicates in the lockfile and the config file.

## Notes
* I renamed a few structures/functions as I was going to help make more sense of the code, so those changes are included here as well.

I don't know if we'll pick this back up at any time, but hopefully this will help me with the problem I was having. 