### PR TITLE
change: updating documentation and altering the way the Logging:insta…

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ Cache: "path/to/global/cache"
 
 # can log the actions and outcomes to a file for debugging and auditing
 Logging:
-  File: pkgr-install.log
+  all: pkgr-log.log
+  install: install-only-log.log
+  overwrite: true
 
 Customizations:
   - devtools:
@@ -141,7 +143,7 @@ For everything else, the default install behavior will stay in effect.
 
 For a third example, here is a configuration that also pulls from bioconductor:
 
-```
+```yaml
 Version: 1
 # top level packages
 Packages:
@@ -173,7 +175,9 @@ Library: pkgs
 
 Cache: pkgcache
 Logging:
-  File: pkgr-install.log
+  all: pkgr-log.log
+  install: install-only-log.log
+  overwrite: true
 ```
 
 # Pkgr and [Packrat](https://rstudio.github.io/packrat/)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -38,11 +38,11 @@ var installCmd = &cobra.Command{
 
 func rInstall(cmd *cobra.Command, args []string) error {
 
-	//Init install-specific log, if one has been set. This overwrites the default log.
+	logger.AddLogFile(cfg.Logging.All, cfg.Logging.Overwrite)
+
+	//Init install-specific log, if one has been set.
 	if cfg.Logging.Install != "" {
 		logger.AddLogFile(cfg.Logging.Install, cfg.Logging.Overwrite)
-	} else {
-		logger.AddLogFile(cfg.Logging.All, cfg.Logging.Overwrite)
 	}
 
 	startTime := time.Now()


### PR DESCRIPTION
…ll option works

Setting Logging:install to a value will no longer prevent pkgr from logging to the "all" log file when pkgr install is run.