### PR TITLE
change: refactored InstallPlan to carry its own download information.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LDFLAGS=-ldflags "-X main.buildTime=${BUILD}"
 MAKE_HOME=${PWD}
 TEST_HOME=${MAKE_HOME}/integration_tests
 
-.PHONY: install test-multiple log-test log-test-reset
+.PHONY: install test-multiple log-test log-test-reset test-master test-master-reset test-mixed test-mixed-reset
 
 install:
 	cd cmd/pkgr; go install ${LDFLAGS}
@@ -17,15 +17,26 @@ test-multiple: install
 	rm -rf simple/test-library/*
 	rm -rf simple-suggests/test-library/*
 
-	-cd ${TEST_HOME}/master; pkgr install
+	cd ${TEST_HOME}/master; pkgr install
 
-	-cd ${TEST_HOME}/mixed-source; pkgr install
+	cd ${TEST_HOME}/mixed-source; pkgr install
 
-	-cd ${TEST_HOME}/pull-source-for-one; pkgr install
+	cd ${TEST_HOME}/pull-source-for-one; pkgr install
 
-	-cd ${TEST_HOME}/simple;	pkgr install
+	cd ${TEST_HOME}/simple;	pkgr install
 
-	#-cd ${TEST_HOME}/simple-suggests; pkgr install
+test-master: install test-master-reset
+
+	cd ${TEST_HOME}/master; pkgr install
+
+test-master-reset:
+	cd ${TEST_HOME}; rm -rf master/test-library/*
+
+test-mixed: install test-mixed-reset
+	cd ${TEST_HOME}/mixed-source; pkgr install
+
+test-mixed-reset:
+	cd ${TEST_HOME}; rm -rf mixed-source/test-library/*
 
 log-test: install log-test-reset
 	cd ${TEST_HOME}/logging-config/install-log; pkgr install

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,13 @@ test-mixed: install test-mixed-reset
 test-mixed-reset:
 	cd ${TEST_HOME}; rm -rf mixed-source/test-library/*
 
+test-simple: install test-simple-reset
+	cd ${TEST_HOME}/simple;	pkgr install
+
+test-simple-reset:
+	cd ${TEST_HOME};rm -rf simple/test-library/*
+
+
 log-test: install log-test-reset
 	cd ${TEST_HOME}/logging-config/install-log; pkgr install
 	cd ${TEST_HOME}/logging-config/default; pkgr install

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -159,35 +159,13 @@ func planInstall(rv cran.RVersion) (*cran.PkgNexus, gpsr.InstallPlan) {
 		}
 		os.Exit(1)
 	}
-	for _, pkg := range availableUserPackages.Packages {
-		log.WithFields(log.Fields{
-			"pkg":     pkg.Package.Package,
-			"repo":    pkg.Config.Repo.Name,
-			"type":    pkg.Config.Type,
-			"version": pkg.Package.Version,
-			"relationship": "user package",
-		}).Info("package repository set")
-	}
+	logUserPackageRepos(availableUserPackages.Packages)
 	installPlan, err := gpsr.ResolveInstallationReqs(cfg.Packages, dependencyConfigurations, pkgNexus)
 	if err != nil {
 		fmt.Println(err)
 		panic(err)
 	}
-
-	for _, pkgToDownload := range installPlan.PackageDownloads {
-		pkg := pkgToDownload.Package.Package
-
-		if !stringInSlice(pkg, cfg.Packages) {
-			log.WithFields(log.Fields{
-				"pkg":     pkgToDownload.Package.Package,
-				"repo":    pkgToDownload.Config.Repo.Name,
-				"type":    pkgToDownload.Config.Type,
-				"version": pkgToDownload.Package.Version,
-				"relationship": "dependency",
-			}).Debug("package repository set")
-		}
-	}
-
+	logDependencyRepos(installPlan.PackageDownloads)
 
 	pkgs := installPlan.StartingPackages
 	for pkg := range installPlan.DepDb {
@@ -223,4 +201,34 @@ func getInstalledPackageNames(installedPackages map[string]desc.Desc) []string {
 	}
 	return installedPackageNames
 }
+
+func logUserPackageRepos(packageDownloads []cran.PkgDl) {
+	for _, pkg := range packageDownloads {
+		log.WithFields(log.Fields{
+			"pkg":          pkg.Package.Package,
+			"repo":         pkg.Config.Repo.Name,
+			"type":         pkg.Config.Type,
+			"version":      pkg.Package.Version,
+			"relationship": "user package",
+		}).Info("package repository set")
+	}
+}
+
+func logDependencyRepos(dependencyDownloads []cran.PkgDl) {
+	for _, pkgToDownload := range dependencyDownloads {
+		pkg := pkgToDownload.Package.Package
+
+		if !stringInSlice(pkg, cfg.Packages) {
+			log.WithFields(log.Fields{
+				"pkg":          pkgToDownload.Package.Package,
+				"repo":         pkgToDownload.Config.Repo.Name,
+				"type":         pkgToDownload.Config.Type,
+				"version":      pkgToDownload.Package.Version,
+				"relationship": "dependency",
+			}).Debug("package repository set")
+		}
+	}
+}
+
+
 

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -165,6 +165,7 @@ func planInstall(rv cran.RVersion) (*cran.PkgNexus, gpsr.InstallPlan) {
 			"repo":    pkg.Config.Repo.Name,
 			"type":    pkg.Config.Type,
 			"version": pkg.Package.Version,
+			"relationship": "user package",
 		}).Info("package repository set")
 	}
 	installPlan, err := gpsr.ResolveInstallationReqs(cfg.Packages, dependencyConfigurations, pkgNexus)
@@ -172,6 +173,22 @@ func planInstall(rv cran.RVersion) (*cran.PkgNexus, gpsr.InstallPlan) {
 		fmt.Println(err)
 		panic(err)
 	}
+
+	for _, pkgToDownload := range installPlan.PackageDownloads {
+		pkg := pkgToDownload.Package.Package
+
+		if !stringInSlice(pkg, cfg.Packages) {
+			log.WithFields(log.Fields{
+				"pkg":     pkgToDownload.Package.Package,
+				"repo":    pkgToDownload.Config.Repo.Name,
+				"type":    pkgToDownload.Config.Type,
+				"version": pkgToDownload.Package.Version,
+				"relationship": "dependency",
+			}).Debug("package repository set")
+		}
+	}
+
+
 	pkgs := installPlan.StartingPackages
 	for pkg := range installPlan.DepDb {
 		pkgs = append(pkgs, pkg)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -95,7 +95,7 @@ func scanInstalledPackage(
 	}
 	defer descriptionFile.Close()
 
-	log.WithField("description_file", descriptionFilePath).Debug("scanning DESCRIPTION file")
+	log.WithField("description_file", descriptionFilePath).Trace("scanning DESCRIPTION file")
 
 	installedPackage, err := desc.ParseDesc(descriptionFile)
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -255,6 +255,15 @@ func CopyDir(fs afero.Fs, src string, dst string) error {
 	return nil
 }
 
+func stringInSlice(s string, slice []string) bool {
+	for _, entry := range slice {
+		if s == entry {
+			return true
+		}
+	}
+	return false
+}
+
 
 type UpdateAttempt struct {
 	Package string

--- a/gpsr/dependencies.go
+++ b/gpsr/dependencies.go
@@ -3,6 +3,7 @@ package gpsr
 import (
 	"errors"
 	"fmt"
+	"github.com/metrumresearchgroup/pkgr/cran"
 
 	"github.com/deckarep/golang-set"
 )
@@ -104,7 +105,7 @@ func ResolveLayers(graph Graph) ([][]string, error) {
 // such that each element contains a slice of all packages that depend on it
 // This can be used when a package is installed to identify which
 // other packages may have all their dependencies satisfied.
-func (ip InstallPlan) InvertDependencies() map[string][]string {
+func (ip *InstallPlan) InvertDependencies() map[string][]string {
 	ddb := ip.DepDb
 	idb := make(map[string][]string)
 	for pkg, deps := range ddb {
@@ -115,4 +116,20 @@ func (ip InstallPlan) InvertDependencies() map[string][]string {
 		}
 	}
 	return idb
+}
+
+func (ip *InstallPlan) Pack(pkgNexus *cran.PkgNexus) {
+	var toDl []cran.PkgDl
+	// starting packages
+	for _, p := range ip.StartingPackages {
+		pkg, cfg, _ := pkgNexus.GetPackage(p)
+		toDl = append(toDl, cran.PkgDl{Package: pkg, Config: cfg})
+	}
+	// all other packages
+	for p := range ip.DepDb {
+		pkg, cfg, _ := pkgNexus.GetPackage(p)
+		toDl = append(toDl, cran.PkgDl{Package: pkg, Config: cfg})
+	}
+	ip.PackageDownloads = toDl
+	//return toDl
 }

--- a/gpsr/solution.go
+++ b/gpsr/solution.go
@@ -59,6 +59,8 @@ func ResolveInstallationReqs(pkgs []string, dependencyConfigs InstallDeps, pkgNe
 			depDb[p] = allDeps
 		}
 	}
-	return InstallPlan{StartingPackages: resolved[0],
-		DepDb: depDb}, nil
+	installPlan := InstallPlan{StartingPackages: resolved[0],
+		DepDb: depDb}
+	installPlan.Pack(pkgNexus)
+	return installPlan, nil
 }

--- a/gpsr/structs.go
+++ b/gpsr/structs.go
@@ -5,7 +5,7 @@ import "github.com/metrumresearchgroup/pkgr/cran"
 //InstallPlan provides metadata around an installation plan
 type InstallPlan struct {
 	StartingPackages []string
-	DepDb            map[string][]string
+	DepDb            map[string][]string // This is a map of the dependencies [D1, D2, ... Dn] for a given package (A). The map is keyed by package name, i.e. DepDb[A] = [D1, D2, ..., Dn]
 	PackageDownloads []cran.PkgDl
 	OutdatedPackages []OutdatedPackage
 }

--- a/gpsr/structs.go
+++ b/gpsr/structs.go
@@ -1,9 +1,12 @@
 package gpsr
 
+import "github.com/metrumresearchgroup/pkgr/cran"
+
 //InstallPlan provides metadata around an installation plan
 type InstallPlan struct {
 	StartingPackages []string
 	DepDb            map[string][]string
+	PackageDownloads []cran.PkgDl
 	OutdatedPackages []OutdatedPackage
 }
 
@@ -28,3 +31,4 @@ type OutdatedPackage struct {
 	OldVersion string
 	NewVersion string
 }
+

--- a/integration_tests/mixed-source/pkgr.yml
+++ b/integration_tests/mixed-source/pkgr.yml
@@ -7,7 +7,7 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  # - CRAN: "https://cran.microsoft.com/snapshot/2018-11-18"
+   - CRAN-Micro: "https://cran.microsoft.com/snapshot/2018-11-18"
    - CRAN: "https://cran.rstudio.com"
 
 Library: "test-library"


### PR DESCRIPTION
This could be done a little cleaner, but I wanted to throw this basic idea out there.

This was a potential refactoring I thought of when looking into #75 . My instincts tell me doing this will be helpful for differentiating between dependencies and user-level packages in the logs, but I haven't quite connected the dots yet.