### PR TITLE
Small features and fixes for 0.5.1/1.0.0

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -18,6 +18,7 @@ import (
 	"github.com/metrumresearchgroup/pkgr/pacman"
 	"github.com/metrumresearchgroup/pkgr/rollback"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/spf13/viper"
@@ -84,7 +85,7 @@ func rInstall(cmd *cobra.Command, args []string) error {
 	// leave at least 1 thread open for coordination, given more than 2 threads available.
 	// if only 2 available, will let the OS hypervisor coordinate some else would drop the
 	// install time too much for the little bit of additional coordination going on.
-	nworkers := GetWorkerCount()
+	nworkers := getWorkerCount(viper.GetInt("threads"), runtime.NumCPU())
 
 	// Process any customizations set in the yaml config file for individual packages.
 	// Set ENV values in rSettings

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -71,6 +71,7 @@ func rInstall(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			log.WithFields(log.Fields{
 				"library" : cfg.Library,
+				"error" : err,
 			}).Fatal("could not create library directory")
 		}
 	}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -97,9 +97,7 @@ func rInstall(cmd *cobra.Command, args []string) error {
 	pkgInstallArgs.Library, _ = filepath.Abs(cfg.Library)
 
 	// Get the number of workers.
-	// leave at least 1 thread open for coordination, given more than 2 threads available.
-	// if only 2 available, will let the OS hypervisor coordinate some else would drop the
-	// install time too much for the little bit of additional coordination going on.
+	// Use number of user defined threads if set. Otherwise, use the number of CPUs (up to 8).
 	nworkers := getWorkerCount(viper.GetInt("threads"), runtime.NumCPU())
 
 	// Process any customizations set in the yaml config file for individual packages.

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -60,6 +60,15 @@ func rInstall(cmd *cobra.Command, args []string) error {
 	//  as well as a master install plan to guide our process.
 	_, installPlan, rollbackPlan := planInstall(rVersion, true)
 
+	if installPlan.CreateLibrary {
+		err := fs.MkdirAll(cfg.Library, 0755)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"library" : cfg.Library,
+			}).Fatal("could not create library directory")
+		}
+	}
+
 	if viper.GetBool("update") {
 		log.Info("update argument passed. staging packages for update...")
 		rollbackPlan.PreparePackagesForUpdate(fs, cfg.Library)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -61,6 +61,12 @@ func rInstall(cmd *cobra.Command, args []string) error {
 	_, installPlan, rollbackPlan := planInstall(rVersion, true)
 
 	if installPlan.CreateLibrary {
+		if cfg.Strict {
+			log.WithFields(log.Fields{
+				"library": cfg.Library,
+			}).Fatal("library directory must exist before running pkgr in strict mode -- halting execution")
+		}
+
 		err := fs.MkdirAll(cfg.Library, 0755)
 		if err != nil {
 			log.WithFields(log.Fields{

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -84,7 +84,7 @@ func rInstall(cmd *cobra.Command, args []string) error {
 	// leave at least 1 thread open for coordination, given more than 2 threads available.
 	// if only 2 available, will let the OS hypervisor coordinate some else would drop the
 	// install time too much for the little bit of additional coordination going on.
-	nworkers := getWorkerCount()
+	nworkers := GetWorkerCount()
 
 	// Process any customizations set in the yaml config file for individual packages.
 	// Set ENV values in rSettings

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -82,7 +82,8 @@ func planInstall(rv cran.RVersion, exitOnMissing bool) (*cran.PkgNexus, gpsr.Ins
 	if err != nil {
 		log.WithFields(log.Fields{
 			"library": cfg.Library,
-		}).Debug("library directory does not exist")
+			"error" : err,
+		}).Error("unexpected error when checking existence of library")
 	}
 
 	if !libraryExists && cfg.Strict {

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -56,7 +56,7 @@ func init() {
 }
 
 func plan(cmd *cobra.Command, args []string) error {
-	log.Infof("Installation would launch %v workers\n", getWorkerCount())
+	log.Infof("Installation would launch %v workers\n", GetWorkerCount())
 	rs := rcmd.NewRSettings(cfg.RPath)
 	rVersion := rcmd.GetRVersion(&rs)
 	log.Infoln("R Version " + rVersion.ToFullString())

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -193,7 +193,7 @@ func planInstall(rv cran.RVersion, exitOnMissing bool) (*cran.PkgNexus, gpsr.Ins
 	}
 
 	totalPackagesRequired := len(pkgs)
-	toInstall := totalPackagesRequired - len(whereInstalledFrom.FromPkgr())
+	toInstall := installPlan.GetNumPackagesToInstall(viper.GetBool("update"))
 	log.WithFields(log.Fields{
 		"total_packages_required": totalPackagesRequired,
 		"installed":               len(installedPackages),

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/metrumresearchgroup/pkgr/rollback"
 
@@ -56,7 +57,7 @@ func init() {
 }
 
 func plan(cmd *cobra.Command, args []string) error {
-	log.Infof("Installation would launch %v workers\n", GetWorkerCount())
+	log.Infof("Installation would launch %v workers\n", getWorkerCount(viper.GetInt("threads"), runtime.NumCPU()))
 	rs := rcmd.NewRSettings(cfg.RPath)
 	rVersion := rcmd.GetRVersion(&rs)
 	log.Infoln("R Version " + rVersion.ToFullString())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,6 +81,9 @@ func init() {
 	RootCmd.PersistentFlags().Bool("update", cfg.Update, "Update packages along with install")
 	_ = viper.BindPFlag("update", RootCmd.PersistentFlags().Lookup("update"))
 
+	RootCmd.PersistentFlags().Bool("strict", cfg.Update, "Enable strict mode")
+	_ = viper.BindPFlag("strict", RootCmd.PersistentFlags().Lookup("strict"))
+
 	// packrat related
 	// RootCmd.PersistentFlags().String("pr_lockfile", "", "packrat lockfile")
 	// viper.BindPFlag("pr_lockfile", RootCmd.PersistentFlags().Lookup("pr_lockfile"))

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -43,11 +43,6 @@ func GetRestrictedWorkerCount(threadCount, numCpus int) int {
 		} else {
 			nworkers = workerCap
 		}
-
-		if nworkers > 2 {
-			nworkers = nworkers - 1
-		}
-
 	} else {
 		nworkers = threadCount
 		if nworkers > numCpus + 2 {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -28,21 +28,35 @@ func userCache(pc string) string {
 	return pkgrCacheDir
 }
 
-func getWorkerCount() int {
+func GetWorkerCount() int {
+	return GetRestrictedWorkerCount(viper.GetInt("threads"), runtime.NumCPU())
+}
+
+// If user has not specified a thread count themselves, will limit the user to 8 threads max to avoid issues.
+func GetRestrictedWorkerCount(threadCount, numCpus int) int {
 	var nworkers int
-	if viper.GetInt("threads") < 1 {
-		nworkers = runtime.NumCPU()
+	if threadCount < 1 { // This indicates that the user has not specified a thread count, i.e. we're using the default thread count of "0".
+
+		workerCap := 8 // We have decided to cap this number at 8 unless the user requests otherwise. This is to prevent issues with cyclic Suggests installs.
+		if numCpus <= workerCap {
+			nworkers = numCpus
+		} else {
+			nworkers = workerCap
+		}
+
 		if nworkers > 2 {
 			nworkers = nworkers - 1
 		}
+
 	} else {
-		nworkers = viper.GetInt("threads")
-		if nworkers > runtime.NumCPU()+2 {
+		nworkers = threadCount
+		if nworkers > numCpus + 2 {
 			log.Warn("number of workers exceeds the number of threads on machine by at least 2, this may result in degraded performance")
 		}
 	}
 	return nworkers
 }
+
 func stringInSlice(s string, slice []string) bool {
 	for _, entry := range slice {
 		if s == entry {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
+	"github.com/spf13/afero"
 	"os"
 	"path/filepath"
-	"runtime"
-
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 // returns the cache or sets to a cache dir
@@ -28,12 +26,8 @@ func userCache(pc string) string {
 	return pkgrCacheDir
 }
 
-func GetWorkerCount() int {
-	return GetRestrictedWorkerCount(viper.GetInt("threads"), runtime.NumCPU())
-}
-
 // If user has not specified a thread count themselves, will limit the user to 8 threads max to avoid issues.
-func GetRestrictedWorkerCount(threadCount, numCpus int) int {
+func getWorkerCount(threadCount, numCpus int) int {
 	var nworkers int
 	if threadCount < 1 { // This indicates that the user has not specified a thread count, i.e. we're using the default thread count of "0".
 
@@ -59,4 +53,9 @@ func stringInSlice(s string, slice []string) bool {
 		}
 	}
 	return false
+}
+
+func libraryExists(fileSystem afero.Fs, libraryPath string ) bool {
+	result, _ := afero.Exists(fileSystem, libraryPath)
+	return result
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -35,11 +35,11 @@ func TestGetRestrictedWorkerCount(t *testing.T) {
 	}
 
 	for _, test := range inputs {
-		executeTestGetRestrictedWorkerCount(t, test.context, test.threads, test.numCpus, test.expectedOutput)
+		executeTestGetWorkerCount(t, test.context, test.threads, test.numCpus, test.expectedOutput)
 	}
 }
 
-func executeTestGetRestrictedWorkerCount(t *testing.T, context string, threads int, numCpus int, expectedOutput int) {
+func executeTestGetWorkerCount(t *testing.T, context string, threads int, numCpus int, expectedOutput int) {
 	t.Log(fmt.Sprintf("context: %s", context))
 	actualResult := getWorkerCount(threads, numCpus)
 	assert.Equal(t, expectedOutput, actualResult, "context: " + context)

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -6,15 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//type UtilsTestSuite struct {
-//	suite.Suite
-//}
-//
-//func TestUtilsTestSuite(t *testing.T) {
-//	suite.Run(t, new(UtilsTestSuite))
-//}
-
-
 func TestGetRestrictedWorkerCount(t *testing.T) {
 
 	type testInput struct {
@@ -50,7 +41,6 @@ func TestGetRestrictedWorkerCount(t *testing.T) {
 
 func executeTestGetRestrictedWorkerCount(t *testing.T, context string, threads int, numCpus int, expectedOutput int) {
 	t.Log(fmt.Sprintf("context: %s", context))
-	actualResult := GetRestrictedWorkerCount(threads, numCpus)
-	assert.Equal(t, expectedOutput, actualResult)
-	t.Log("PASS")
+	actualResult := getWorkerCount(threads, numCpus)
+	assert.Equal(t, expectedOutput, actualResult, "context: " + context)
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+//type UtilsTestSuite struct {
+//	suite.Suite
+//}
+//
+//func TestUtilsTestSuite(t *testing.T) {
+//	suite.Run(t, new(UtilsTestSuite))
+//}
+
+
+func TestGetRestrictedWorkerCount(t *testing.T) {
+
+	type testInput struct {
+		context string
+		threads int
+		numCpus int
+		expectedOutput int
+	}
+
+	inputs := []testInput {
+		{"2 CPUs, no thread set", 0, 2, 2},
+		{ "3 CPUs, no thread set", 0, 3, 2},
+		{ "4 CPUs, no thread set", 0, 4, 3},
+		{ "8 CPUs, no thread set", 0, 8, 7},
+		{ "9 CPUs, no thread set", 0, 9, 7},
+		{ "9 CPUs, no thread set", 0, 9, 7},
+		{ "4 CPUs, 2 threads set", 2, 4, 2},
+		{ "4 CPUs, 4 threads set", 4, 4, 4},
+		{ "4 CPUs, 5 threads set", 5, 4, 5},
+		{ "4 CPUs, 6 threads set", 6, 4, 6},
+		{ "4 CPUs, 7 threads set", 7, 4, 7},
+		{ "8 CPUs, 8 threads set", 8, 8, 8},
+		{ "8 CPUs, 16 threads set", 16, 8, 16},
+	}
+
+	for _, test := range inputs {
+		executeTestGetRestrictedWorkerCount(t, test.context, test.threads, test.numCpus, test.expectedOutput)
+	}
+}
+
+func executeTestGetRestrictedWorkerCount(t *testing.T, context string, threads int, numCpus int, expectedOutput int) {
+	t.Log(fmt.Sprintf("context: %s", context))
+	actualResult := GetRestrictedWorkerCount(threads, numCpus)
+	assert.Equal(t, expectedOutput, actualResult)
+	t.Log("PASS")
+}

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -25,18 +25,21 @@ func TestGetRestrictedWorkerCount(t *testing.T) {
 	}
 
 	inputs := []testInput {
+		{"1 CPU, no thread set", 0, 1, 1},
 		{"2 CPUs, no thread set", 0, 2, 2},
-		{ "3 CPUs, no thread set", 0, 3, 2},
-		{ "4 CPUs, no thread set", 0, 4, 3},
-		{ "8 CPUs, no thread set", 0, 8, 7},
-		{ "9 CPUs, no thread set", 0, 9, 7},
-		{ "9 CPUs, no thread set", 0, 9, 7},
+		{ "3 CPUs, no thread set", 0, 3, 3},
+		{ "4 CPUs, no thread set", 0, 4, 4},
+		{ "8 CPUs, no thread set", 0, 8, 8},
+		{ "9 CPUs, no thread set", 0, 9, 8},
+		{ "16 CPUs, no thread set", 0, 16, 8},
 		{ "4 CPUs, 2 threads set", 2, 4, 2},
 		{ "4 CPUs, 4 threads set", 4, 4, 4},
 		{ "4 CPUs, 5 threads set", 5, 4, 5},
 		{ "4 CPUs, 6 threads set", 6, 4, 6},
 		{ "4 CPUs, 7 threads set", 7, 4, 7},
 		{ "8 CPUs, 8 threads set", 8, 8, 8},
+		{ "8 CPUs, 9 threads set", 9, 8, 9},
+		{ "8 CPUs, 10 threads set", 10, 8, 10},
 		{ "8 CPUs, 16 threads set", 16, 8, 16},
 	}
 

--- a/configlib/config.go
+++ b/configlib/config.go
@@ -65,7 +65,7 @@ func LoadConfigFromPath(configFilename string) error {
 	if err != nil {
 		// panic if can't find or parse config as this could be explicit to user expectations
 		if _, ok := err.(*os.PathError); ok {
-			panic(fmt.Errorf("could not find a config file at path: %s", configFilename))
+			log.Fatalf("could not find a config file at path: %s", configFilename)
 		}
 	}
 	expb := []byte(os.ExpandEnv(string(b)))
@@ -73,7 +73,7 @@ func LoadConfigFromPath(configFilename string) error {
 	if err != nil {
 		if _, ok := err.(viper.ConfigParseError); ok {
 			// found config file but couldn't parse it, should error
-			panic(fmt.Errorf("unable to parse config file with error (%s)", err))
+			log.Fatalf("unable to parse config file with error (%s)", err)
 		}
 		// maybe could be more loose on this later, but for now will require a config file
 		fmt.Println("Error with pkgr config file:")

--- a/configlib/config.go
+++ b/configlib/config.go
@@ -93,6 +93,7 @@ func loadDefaultSettings() {
 	// path to R on system, defaults to R in path
 	viper.SetDefault("rpath", "R")
 	viper.SetDefault("threads", 0)
+	viper.SetDefault("strict", false)
 }
 
 // IsCustomizationSet ...

--- a/configlib/structs.go
+++ b/configlib/structs.go
@@ -51,5 +51,5 @@ type PkgrConfig struct {
 	Logging        LogConfig           `yaml:"Logging,omitempty"`
 	Update         bool                `yaml:"Update,omitempty"`
 	Lockfile       Lockfile            `yaml:"Lockfile,omitempty"`
-	Strict				 bool								 `yaml:"Strict,omitempty"`
+	Strict         bool                `yaml:"Strict,omitempty"`
 }

--- a/configlib/structs.go
+++ b/configlib/structs.go
@@ -51,4 +51,5 @@ type PkgrConfig struct {
 	Logging        LogConfig           `yaml:"Logging,omitempty"`
 	Update         bool                `yaml:"Update,omitempty"`
 	Lockfile       Lockfile            `yaml:"Lockfile,omitempty"`
+	Strict				 bool								 `yaml:"Strict,omitempty"`
 }

--- a/configlib/viper_test.go
+++ b/configlib/viper_test.go
@@ -30,6 +30,10 @@ import (
 //         	            	Expected:[R6 pillar]
 //         	            	Actual:[abc shiny R6 pillar]
 
+// ATTENTION:
+// This test is misconfigured, it shouldn't be pointing to the integration test folders as those folders are only valid
+// after make test-install has been run from the integration_tests folder.
+// This test might fail falsey depending on the current state of pkgr/integration_tests/simple/test-library
 func TestViper(t *testing.T) {
 	tests := []struct {
 		ymlfolder string

--- a/gpsr/dependencies.go
+++ b/gpsr/dependencies.go
@@ -143,7 +143,7 @@ func (ip *InstallPlan) GetAllPackages() []string {
 	return toInstall
 }
 
-func (ip *InstallPlan) GetNumPackagesToInstall(includeOutdated bool) int {
+func (ip *InstallPlan) GetNumPackagesToInstall() int {
 	requiredPackages := ip.GetAllPackages()
 
 
@@ -156,7 +156,7 @@ func (ip *InstallPlan) GetNumPackagesToInstall(includeOutdated bool) int {
 	}
 	toUpdate := 0
 	// Everything in OutdatedPackages should be required, otherwise pkgr wouldn't have checked for an updated version.
-	if includeOutdated {
+	if ip.Update {
 		toUpdate = len(ip.OutdatedPackages)
 	}
 	return len(requiredPackages) - installedRequired + toUpdate

--- a/gpsr/dependencies.go
+++ b/gpsr/dependencies.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/metrumresearchgroup/pkgr/cran"
+	"github.com/thoas/go-funk"
 
 	"github.com/deckarep/golang-set"
 )
@@ -140,4 +141,24 @@ func (ip *InstallPlan) GetAllPackages() []string {
 		toInstall = append(toInstall, depsList)
 	}
 	return toInstall
+}
+
+func (ip *InstallPlan) GetNumPackagesToInstall(includeOutdated bool) int {
+	requiredPackages := ip.GetAllPackages()
+
+
+	// Handle the case where packages not requested via pkgr.yml (or dependencies) are present in directory.
+	installedRequired := 0
+	for p := range ip.InstalledPackages {
+		if funk.Contains(requiredPackages, p) {
+			installedRequired = installedRequired + 1
+		}
+	}
+	toUpdate := 0
+	// Everything in OutdatedPackages should be required, otherwise pkgr wouldn't have checked for an updated version.
+	if includeOutdated {
+		toUpdate = len(ip.OutdatedPackages)
+	}
+	return len(requiredPackages) - installedRequired + toUpdate
+
 }

--- a/gpsr/solution.go
+++ b/gpsr/solution.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ResolveInstallationReqs resolves all the installation requirements
-func ResolveInstallationReqs(pkgs []string, preinstalledPkgs map[string]desc.Desc, dependencyConfigs InstallDeps, pkgNexus *cran.PkgNexus) (InstallPlan, error) {
+func ResolveInstallationReqs(libraryExists bool, pkgs []string, preinstalledPkgs map[string]desc.Desc, dependencyConfigs InstallDeps, pkgNexus *cran.PkgNexus) (InstallPlan, error) {
 
 	workingGraph := NewGraph()
 	defaultDependencyConfigs := NewDefaultInstallDeps()
@@ -70,6 +70,7 @@ func ResolveInstallationReqs(pkgs []string, preinstalledPkgs map[string]desc.Des
 		DepDb: depDb,
 		InstalledPackages: preinstalledPkgs,
 		OutdatedPackages: outdatedPackages,
+		CreateLibrary: !libraryExists,
 	}
 	installPlan.Pack(pkgNexus)
 	return installPlan, nil

--- a/gpsr/solution.go
+++ b/gpsr/solution.go
@@ -9,7 +9,14 @@ import (
 )
 
 // ResolveInstallationReqs resolves all the installation requirements
-func ResolveInstallationReqs(libraryExists bool, pkgs []string, preinstalledPkgs map[string]desc.Desc, dependencyConfigs InstallDeps, pkgNexus *cran.PkgNexus) (InstallPlan, error) {
+func ResolveInstallationReqs(
+		pkgs []string,
+		preinstalledPkgs map[string]desc.Desc,
+		dependencyConfigs InstallDeps,
+		pkgNexus *cran.PkgNexus,
+		update bool,
+		libraryExists bool,
+	) (InstallPlan, error) {
 
 	workingGraph := NewGraph()
 	defaultDependencyConfigs := NewDefaultInstallDeps()
@@ -66,11 +73,12 @@ func ResolveInstallationReqs(libraryExists bool, pkgs []string, preinstalledPkgs
 	outdatedPackages := pacman.GetOutdatedPackages(preinstalledPkgs, pkgNexus.GetPackages(extractNamesFromDesc(preinstalledPkgs)).Packages)
 
 	installPlan := InstallPlan{
-		StartingPackages: resolved[0],
-		DepDb: depDb,
+		StartingPackages:  resolved[0],
+		DepDb:             depDb,
 		InstalledPackages: preinstalledPkgs,
-		OutdatedPackages: outdatedPackages,
-		CreateLibrary: !libraryExists,
+		OutdatedPackages:  outdatedPackages,
+		CreateLibrary:     !libraryExists,
+		Update:            update,
 	}
 	installPlan.Pack(pkgNexus)
 	return installPlan, nil

--- a/gpsr/structs.go
+++ b/gpsr/structs.go
@@ -12,6 +12,7 @@ type InstallPlan struct {
 	PackageDownloads []cran.PkgDl
 	OutdatedPackages []cran.OutdatedPackage
 	InstalledPackages map[string]desc.Desc
+	CreateLibrary bool
 }
 
 // PkgDeps contains which dependencies should be installed

--- a/gpsr/structs.go
+++ b/gpsr/structs.go
@@ -13,6 +13,7 @@ type InstallPlan struct {
 	OutdatedPackages []cran.OutdatedPackage
 	InstalledPackages map[string]desc.Desc
 	CreateLibrary bool
+	Update bool
 }
 
 // PkgDeps contains which dependencies should be installed

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -5,12 +5,12 @@ LDFLAGS=-ldflags "-X main.buildTime=${BUILD}"
 BUILD_HOME=${PWD}/../cmd/pkgr
 TEST_HOME=${PWD}
 
-.PHONY: install test-setup test-mixed-source-reset test-simple-reset test-threads-reset test-logging-config-reset test-outdated-pkgs-reset test-repo-order-reset test-repo-local-reset test-repo-local-and-remote-reset test-rollback-reset test-simple-suggests-reset test-rollback-reset
+.PHONY: install test-setup test-mixed-source-reset test-simple-reset test-threads-reset test-logging-config-reset test-outdated-pkgs-reset test-repo-order-reset test-repo-local-reset test-repo-local-and-remote-reset test-rollback-reset test-simple-suggests-reset test-rollback-reset test-create-library-reset test-strict-mode-reset 
 
 install:
 	cd ${BUILD_HOME}; go install ${LDFLAGS}
 
-test-setup: test-mixed-source-reset test-simple-reset test-threads-reset test-logging-config-reset test-outdated-pkgs-reset test-outdated-pkgs-stress-reset test-repo-order-reset test-repo-local-reset test-repo-local-and-remote-reset test-simple-suggests-reset test-rollback-reset install
+test-setup: test-mixed-source-reset test-simple-reset test-threads-reset test-logging-config-reset test-outdated-pkgs-reset test-outdated-pkgs-stress-reset test-repo-order-reset test-repo-local-reset test-repo-local-and-remote-reset test-simple-suggests-reset test-rollback-reset test-create-library-reset test-strict-mode-reset install
 
 
 test-mixed-source-reset:
@@ -75,3 +75,9 @@ test-rollback-reset:
 	cd ${TEST_HOME}/rollback; rm -rf test-library/
 	cd ${TEST_HOME}/rollback; mkdir test-library/
 	cd ${TEST_HOME}/rollback; cp -r ${TEST_HOME}/rollback/preinstalled-library/* ${TEST_HOME}/rollback/test-library
+
+test-create-library-reset:
+	cd ${TEST_HOME}/create-library; rm -rf test-library/
+
+test-strict-mode-reset:
+	cd ${TEST_HOME}/strict-mode; rm -rf test-library/

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -5,12 +5,12 @@ LDFLAGS=-ldflags "-X main.buildTime=${BUILD}"
 BUILD_HOME=${PWD}/../cmd/pkgr
 TEST_HOME=${PWD}
 
-.PHONY: install test-setup test-mixed-source-reset test-simple-reset test-threads-reset test-logging-config-reset test-outdated-pkgs-reset test-repo-order-reset test-repo-local-reset test-repo-local-and-remote-reset test-rollback-reset test-simple-suggests-reset test-rollback-reset test-create-library-reset test-strict-mode-reset 
+.PHONY: install test-setup test-mixed-source-reset test-simple-reset test-threads-reset test-logging-config-reset test-outdated-pkgs-reset test-repo-order-reset test-repo-local-reset test-repo-local-and-remote-reset test-rollback-reset test-simple-suggests-reset test-rollback-reset test-create-library-reset test-strict-mode-reset test-outdated-pkgs-no-update-reset
 
 install:
 	cd ${BUILD_HOME}; go install ${LDFLAGS}
 
-test-setup: test-mixed-source-reset test-simple-reset test-threads-reset test-logging-config-reset test-outdated-pkgs-reset test-outdated-pkgs-stress-reset test-repo-order-reset test-repo-local-reset test-repo-local-and-remote-reset test-simple-suggests-reset test-rollback-reset test-create-library-reset test-strict-mode-reset install
+test-setup: test-mixed-source-reset test-simple-reset test-threads-reset test-logging-config-reset test-outdated-pkgs-reset test-outdated-pkgs-stress-reset test-repo-order-reset test-repo-local-reset test-repo-local-and-remote-reset test-simple-suggests-reset test-rollback-reset test-create-library-reset test-strict-mode-reset test-outdated-pkgs-no-update-reset install
 
 
 test-mixed-source-reset:
@@ -47,6 +47,11 @@ test-outdated-pkgs-reset:
 	rm -rf ${TEST_HOME}/outdated-pkgs/test-library/
 	mkdir ${TEST_HOME}/outdated-pkgs/test-library
 	cp -r ${TEST_HOME}/outdated-pkgs/outdated-library/* ${TEST_HOME}/outdated-pkgs/test-library/
+
+test-outdated-pkgs-no-update-reset:
+	rm -rf ${TEST_HOME}/outdated-pkgs-no-update/test-library/
+	mkdir ${TEST_HOME}/outdated-pkgs-no-update/test-library
+	cp -r ${TEST_HOME}/outdated-pkgs-no-update/outdated-library/* ${TEST_HOME}/outdated-pkgs-no-update/test-library/
 
 test-outdated-pkgs-stress-reset:
 	rm -rf ${TEST_HOME}/outdated-pkgs-stress/test-library/

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -5,12 +5,12 @@ LDFLAGS=-ldflags "-X main.buildTime=${BUILD}"
 BUILD_HOME=${PWD}/../cmd/pkgr
 TEST_HOME=${PWD}
 
-.PHONY: install test-setup test-mixed-source-reset test-simple-reset test-logging-config-reset test-outdated-pkgs-reset test-repo-order-reset test-repo-local-reset test-repo-local-and-remote-reset test-rollback-reset test-simple-suggests-reset test-rollback-reset
+.PHONY: install test-setup test-mixed-source-reset test-simple-reset test-threads-reset test-logging-config-reset test-outdated-pkgs-reset test-repo-order-reset test-repo-local-reset test-repo-local-and-remote-reset test-rollback-reset test-simple-suggests-reset test-rollback-reset
 
 install:
 	cd ${BUILD_HOME}; go install ${LDFLAGS}
 
-test-setup: test-mixed-source-reset test-simple-reset test-logging-config-reset test-outdated-pkgs-reset test-outdated-pkgs-stress-reset test-repo-order-reset test-repo-local-reset test-repo-local-and-remote-reset test-simple-suggests-reset test-rollback-reset install
+test-setup: test-mixed-source-reset test-simple-reset test-threads-reset test-logging-config-reset test-outdated-pkgs-reset test-outdated-pkgs-stress-reset test-repo-order-reset test-repo-local-reset test-repo-local-and-remote-reset test-simple-suggests-reset test-rollback-reset install
 
 
 test-mixed-source-reset:
@@ -22,6 +22,10 @@ test-mixed-source-reset:
 test-simple-reset:
 	cd ${TEST_HOME}/simple; rm -rf test-library/
 	cd ${TEST_HOME}/simple; mkdir test-library/
+
+test-threads-reset:
+	cd ${TEST_HOME}/threads; rm -rf test-library/
+	cd ${TEST_HOME}/threads; mkdir test-library/
 
 test-logging-config-reset:
 	cd ${TEST_HOME}/logging-config/install-log; rm -rf logs/

--- a/integration_tests/create-library/.gitignore
+++ b/integration_tests/create-library/.gitignore
@@ -1,0 +1,1 @@
+test-library

--- a/integration_tests/create-library/guide.md
+++ b/integration_tests/create-library/guide.md
@@ -1,0 +1,17 @@
+# create-library
+
+## Description
+Very simple pkgr environment meant to easily test that a library is created when
+it does not exist.
+
+## Expected Behaviors
+* `pkgr plan` will indicate test-library will be created
+* `pkgr install` will create test-library and install the following packages
+  - R6 (**user package**)
+  - pillar (**user package**)
+  - rlang (dependency)
+  - cli (dependency)
+  - utf8 (dependency)
+  - fansi (dependency)
+  - assertthat (dependency)
+  - crayon (dependency)

--- a/integration_tests/create-library/pkgr.yml
+++ b/integration_tests/create-library/pkgr.yml
@@ -1,0 +1,13 @@
+Version: 1
+
+# top level packages
+Packages:
+  - R6
+  - pillar
+
+# any repositories, order matters
+Repos:
+  - CRAN: "https://cran.microsoft.com/snapshot/2019-05-01"
+
+# Does not exist in this test case.
+Library: "test-library"

--- a/integration_tests/customization/pkgr.yml
+++ b/integration_tests/customization/pkgr.yml
@@ -7,8 +7,8 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.rstudio.com" 
-  - CRAN2: "https://cran.rstudio.com" 
+  - CRAN: "https://cran.microsoft.com/snapshot/2019-11-01" 
+  - CRAN2: "https://cran.microsoft.com/snapshot/2019-05-01"
 
 Library: "test-library"
 

--- a/integration_tests/logging-config/install-log/pkgr.yml
+++ b/integration_tests/logging-config/install-log/pkgr.yml
@@ -6,11 +6,10 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.rstudio.com"
+  - CRAN: "https://cran.microsoft.com/snapshot/2019-05-01"
 
 Library: "test-library"
 
 Logging:
   all: logs/all.log
   install: logs/install.log
-  

--- a/integration_tests/logging-config/overwrite-setting/pkgr.yml
+++ b/integration_tests/logging-config/overwrite-setting/pkgr.yml
@@ -6,7 +6,7 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.rstudio.com"
+  - CRAN: "https://cran.microsoft.com/snapshot/2019-05-01"
 
 Library: "test-library"
 
@@ -14,4 +14,3 @@ Logging:
   all: logs/all.log
   install: logs/install.log
   overwrite: true
-  

--- a/integration_tests/outdated-pkgs-no-update/backup1/Matrix/DESCRIPTION
+++ b/integration_tests/outdated-pkgs-no-update/backup1/Matrix/DESCRIPTION
@@ -1,0 +1,51 @@
+Package: Matrix
+Version: 1.2-11
+Date: 2018-09-15
+Priority: recommended
+Title: Sparse and Dense Matrix Classes and Methods
+Contact: Doug and Martin <Matrix-authors@R-project.org>
+Maintainer: Martin Maechler <mmaechler+Matrix@gmail.com>
+Authors@R: c(person("Douglas","Bates", role="aut")
+ , person("Martin","Maechler", role = c("aut","cre"), email="mmaechler+Matrix@gmail.com",
+          comment = c(ORCID = "0000-0002-8685-9910"))
+ , person("Timothy A.", "Davis", role="ctb",
+           comment = c("SuiteSparse and 'cs' C libraries, notably CHOLMOD, AMD;
+		       collaborators listed in
+			dir(pattern = '^[A-Z]+[.]txt$', full.names=TRUE,
+			    system.file('doc', 'SuiteSparse', package='Matrix'))"))
+ , person("Jens", "Oehlschlägel", role="ctb", comment="initial nearPD()")
+ , person("Jason", "Riedy", role="ctb",
+          comment = c("condest() and onenormest() for octave",
+ 	  	      "Copyright: Regents of the University of California"))
+ , person("R Core Team", role = "ctb", comment="base R matrix implementation")
+ )
+Description: A rich hierarchy of matrix classes, including triangular,
+   symmetric, and diagonal matrices, both dense and sparse and with
+   pattern, logical and numeric entries.   Numerous methods for and
+   operations on these matrices, using 'LAPACK' and 'SuiteSparse' libraries.
+Depends: R (>= 3.2.0)
+Imports: methods, graphics, grid, stats, utils, lattice
+Suggests: expm, MASS
+Enhances: MatrixModels, graph, SparseM, sfsmisc
+Encoding: UTF-8
+LazyData: no
+LazyDataNote: not possible, since we use data/*.R *and* our classes
+BuildResaveData: no
+License: GPL (>= 2) | file LICENCE
+URL: http://Matrix.R-forge.R-project.org/
+BugReports: https://r-forge.r-project.org/tracker/?group_id=61
+NeedsCompilation: yes
+Packaged: 2018-10-26 07:17:47 UTC; maechler
+Author: Douglas Bates [aut],
+  Martin Maechler [aut, cre] (<https://orcid.org/0000-0002-8685-9910>),
+  Timothy A. Davis [ctb] (SuiteSparse and 'cs' C libraries, notably
+    CHOLMOD, AMD; collaborators listed in dir(pattern =
+    '^[A-Z]+[.]txt$', full.names=TRUE, system.file('doc',
+    'SuiteSparse', package='Matrix'))),
+  Jens Oehlschlägel [ctb] (initial nearPD()),
+  Jason Riedy [ctb] (condest() and onenormest() for octave, Copyright:
+    Regents of the University of California),
+  R Core Team [ctb] (base R matrix implementation)
+Repository: CRAN
+Date/Publication: 2018-11-01 18:30:04 UTC
+Built: R 3.5.3; x86_64-apple-darwin15.6.0; 2019-03-13 14:34:44 UTC; unix

--- a/integration_tests/outdated-pkgs-no-update/backup1/R6/DESCRIPTION
+++ b/integration_tests/outdated-pkgs-no-update/backup1/R6/DESCRIPTION
@@ -1,0 +1,23 @@
+Package: R6
+Title: Classes with reference semantics
+Version: 2.0
+Authors@R: "Winston Chang <winston@stdout.org> [aut, cre]"
+Description: The R6 package allows the creation of classes with reference
+    semantics, similar to R's built-in reference classes. Compared to reference
+    classes, R6 classes are simpler and lighter-weight, and they are not built
+    on S4 classes so they do not require the methods package. These classes
+    allow public and private members, and they support inheritance, even when
+    the classes are defined in different packages.
+Depends: R (>= 3.0)
+Suggests: knitr, pryr, testthat,
+License: MIT + file LICENSE
+URL: https://github.com/wch/R6/
+LazyData: true
+VignetteBuilder: knitr
+Packaged: 2014-08-19 05:13:57 UTC; winston
+Author: "Winston Chang" [aut, cre]
+Maintainer: "Winston Chang" <winston@stdout.org>
+NeedsCompilation: no
+Repository: CRAN
+Date/Publication: 2014-08-19 07:54:18
+Built: R 3.5.3; ; 2019-04-10 14:49:05 UTC; unix

--- a/integration_tests/outdated-pkgs-no-update/backup1/crayon/DESCRIPTION
+++ b/integration_tests/outdated-pkgs-no-update/backup1/crayon/DESCRIPTION
@@ -1,0 +1,35 @@
+Package: crayon
+Title: Colored Terminal Output
+Version: 1.2.1
+Authors@R: c(
+    person("Gábor", "Csárdi", , "csardi.gabor@gmail.com",
+    role = c("aut", "cre")),
+    person(
+    "Brodie", "Gaslam", email="brodie.gaslam@yahoo.com",
+    role=c("ctb"))
+    )
+Description: Colored terminal output on terminals that support 'ANSI'
+    color and highlight codes. It also works in 'Emacs' 'ESS'. 'ANSI'
+    color support is automatically detected. Colors and highlighting can
+    be combined and nested. New styles can also be created easily.
+    This package was inspired by the 'chalk' 'JavaScript' project.
+License: MIT + file LICENSE
+LazyData: true
+URL: https://github.com/r-lib/crayon#readme
+BugReports: https://github.com/r-lib/crayon/issues
+Collate: 'ansi-256.r' 'combine.r' 'string.r' 'utils.r'
+        'crayon-package.r' 'disposable.r' 'has_ansi.r' 'has_color.r'
+        'styles.r' 'machinery.r' 'parts.r' 'print.r' 'style-var.r'
+        'show.r' 'string_operations.r'
+Imports: grDevices, methods, utils
+Suggests: mockery, rstudioapi, testthat, withr
+RoxygenNote: 6.0.1.9000
+Encoding: UTF-8
+NeedsCompilation: no
+Packaged: 2017-09-15 18:14:04 UTC; gaborcsardi
+Author: Gábor Csárdi [aut, cre],
+  Brodie Gaslam [ctb]
+Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>
+Repository: CRAN
+Date/Publication: 2017-09-16 19:49:46 UTC
+Built: R 3.5.0; ; 2018-04-23 04:01:40 UTC; unix

--- a/integration_tests/outdated-pkgs-no-update/backup1/pillar/DESCRIPTION
+++ b/integration_tests/outdated-pkgs-no-update/backup1/pillar/DESCRIPTION
@@ -1,0 +1,34 @@
+Package: pillar
+Title: Coloured Formatting for Columns
+Version: 1.2.1
+Authors@R: c(
+    person("Kirill", "Müller", , "krlmlr+r@mailbox.org", role = c("aut", "cre")),
+    person("Hadley", "Wickham", role = "aut"),
+    person("RStudio", role = "cph")
+  )
+Description: Provides a 'pillar' generic designed for formatting columns
+   of data using the full range of colours provided by modern terminals.
+License: GPL-3
+Encoding: UTF-8
+LazyData: true
+URL: https://github.com/r-lib/pillar
+BugReports: https://github.com/r-lib/pillar/issues
+Imports: cli (>= 1.0.0), crayon (>= 1.3.4), methods, rlang (>= 0.2.0),
+        utf8 (>= 1.1.3)
+Suggests: knitr (>= 1.19), lubridate, testthat (>= 2.0.0)
+RoxygenNote: 6.0.1.9000
+Collate: 'capital.R' 'compat-purrr.R' 'dim.R' 'extent.R' 'multi.R'
+        'ornament.R' 'pillar-package.R' 'pillar.R' 'rowid-capital.R'
+        'rowid-data.R' 'rowid-title.R' 'rowid-type.R' 'scientific.R'
+        'shaft.R' 'shaft-simple.R' 'sigfig.R' 'spark-bar.R'
+        'spark-line.R' 'strrep.R' 'styles.R' 'testthat.R' 'tick.R'
+        'title.R' 'type-sum.R' 'type.R' 'utils.R' 'width.R' 'zzz.R'
+NeedsCompilation: no
+Packaged: 2018-02-27 05:56:38 UTC; muelleki
+Author: Kirill Müller [aut, cre],
+  Hadley Wickham [aut],
+  RStudio [cph]
+Maintainer: Kirill Müller <krlmlr+r@mailbox.org>
+Repository: CRAN
+Date/Publication: 2018-02-27 12:42:32 UTC
+Built: R 3.5.3; ; 2019-04-10 14:50:08 UTC; unix

--- a/integration_tests/outdated-pkgs-no-update/backup1/utf9/DESCRIPTION
+++ b/integration_tests/outdated-pkgs-no-update/backup1/utf9/DESCRIPTION
@@ -1,0 +1,31 @@
+Package: utf9
+Version: 1.1.5
+Title: Unicode Text Processing
+Authors@R: c(
+  person(c("Patrick", "O."), "Perry",
+         role = c("aut", "cph", "cre"),
+         email = "patperry@gmail.com"),
+  person("Unicode, Inc.",
+         role = c("cph", "dtc"),
+         comment = "Unicode Character Database"))
+Depends: R (>= 2.10)
+Suggests: knitr, rmarkdown, testthat
+Description: Process and print 'UTF-8' encoded international text (Unicode). Input, validate, normalize, encode, format, and display.
+License: Apache License (== 2.0) | file LICENSE
+URL: https://github.com/patperry/r-utf8
+BugReports: https://github.com/patperry/r-utf8/issues
+LazyData: Yes
+Encoding: UTF-8
+VignetteBuilder: knitr, rmarkdown
+NeedsCompilation: yes
+Packaged: 2018-05-24 15:00:57 UTC; ptrck
+Author: Patrick O. Perry [aut, cph, cre],
+  Unicode, Inc. [cph, dtc] (Unicode Character Database)
+Maintainer: Patrick O. Perry <patperry@gmail.com>
+Repository: CRAN
+Date/Publication: 2018-05-24 17:09:15 UTC
+Built: R 3.6.0; x86_64-apple-darwin15.6.0; 2019-04-26 19:50:07 UTC; unix
+Archs: utf8.so.dSYM
+PkgrVersion: 0.5.0-rc.1-2019-11-07T17:50:13-0500
+PkgrInstallType: binary
+PkgrRepositoryURL: https://cran.microsoft.com/snapshot/2019-05-01

--- a/integration_tests/outdated-pkgs-no-update/guide.md
+++ b/integration_tests/outdated-pkgs-no-update/guide.md
@@ -1,0 +1,23 @@
+# outdated-pkgs-no-update
+
+## Description
+
+Environment to help test the "--update" [flag or config setting]. The environment is configured for the same packages as [simple](../simple/guide.md), plus the base-R package `Matrix`\*.
+
+\* Note: We included the "Matrix" package here because a user had trouble using this feature with Matrix. It's mainly here as a regression test.
+
+** DO NOT MODIFY THE [outdated-library](outdated-library) DIRECTORY OR YOU WILL DESTROY THIS ENVIRONMENT **
+
+## Expected behavior
+
+You can modify the [pkgr.yml](pkgr.yml) file by setting the `Update` value to `true` or `false`. By default, this test case does not specify, so it should default to FALSE.
+
+* **Update True**:
+  - `pkgr plan` indicates that four packages are outdated: `R6`, `pillar`, and `Matrix`, plus `crayon`, which is a dependency of pillar.
+
+  - `pkgr install` will install the most recent versions of `R6`, `pillar`, `Matrix`, and `crayon`, as well as several other dependenceis.
+
+* **Update False**
+  - `pkgr plan` will warn that `R6`, `pillar`, `Matrix`, and `crayon` are outdated.
+  - `pkgr install` will leave `R6`, `pillar`, `Matrix`, and `crayon` alone (their versions will not be updated) and will only install the dependencies not already installed.
+  - `pkgr plan --update` and `pkgr install --update` will behave as if the Update flag was set to "true" in the config file.

--- a/integration_tests/outdated-pkgs-no-update/pkgr.yml
+++ b/integration_tests/outdated-pkgs-no-update/pkgr.yml
@@ -8,6 +8,6 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.rstudio.com"
+  - CRAN: "https://cran.microsoft.com/snapshot/2019-11-01"
 
 Library: "test-library"

--- a/integration_tests/packrat-library/pkgr.yml
+++ b/integration_tests/packrat-library/pkgr.yml
@@ -9,6 +9,6 @@ Lockfile:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.rstudio.com"
+  - CRAN: "https://cran.microsoft.com/snapshot/2019-05-01"
 
 #Library: "test-library"

--- a/integration_tests/repo-local/pkgr.yml
+++ b/integration_tests/repo-local/pkgr.yml
@@ -6,7 +6,7 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - miniCRAN: "/Users/johncarlos/go/src/github.com/metrumresearchgroup/pkgr/integration_tests/minicran"
+  - miniCRAN: "../minicran"
 
 Library: "test-library"
 

--- a/integration_tests/repo-order/pkgr.yml
+++ b/integration_tests/repo-order/pkgr.yml
@@ -5,7 +5,7 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.rstudio.com"
+  - CRAN: "https://cran.microsoft.com/snapshot/2019-05-01"
   - r_validated: "https://metrumresearchgroup.github.io/r_validated"
 
 Library: "test-library"

--- a/integration_tests/simple/pkgr.yml
+++ b/integration_tests/simple/pkgr.yml
@@ -6,6 +6,6 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.rstudio.com"
+  - CRAN: "https://cran.microsoft.com/snapshot/2019-05-01"
 
 Library: "test-library"

--- a/integration_tests/strict-mode/.gitignore
+++ b/integration_tests/strict-mode/.gitignore
@@ -1,0 +1,1 @@
+test-library

--- a/integration_tests/strict-mode/guide.md
+++ b/integration_tests/strict-mode/guide.md
@@ -4,13 +4,5 @@
 Verify that strict-mode enforces pre-created library folder.
 
 ## Expected Behaviors
-* `pkgr plan` will indicate test-library will be created
-* `pkgr install` will create test-library and install the following packages
-  - R6 (**user package**)
-  - pillar (**user package**)
-  - rlang (dependency)
-  - cli (dependency)
-  - utf8 (dependency)
-  - fansi (dependency)
-  - assertthat (dependency)
-  - crayon (dependency)
+* `pkgr plan` will indicate via error message that the library must exist before running in strict-mode.
+* `pkgr install` will display a fatal error message saying that the library must exist before running in strict-mode. No library will be created nor packages installed.

--- a/integration_tests/strict-mode/guide.md
+++ b/integration_tests/strict-mode/guide.md
@@ -1,0 +1,16 @@
+# strict-mode
+
+## Description
+Verify that strict-mode enforces pre-created library folder.
+
+## Expected Behaviors
+* `pkgr plan` will indicate test-library will be created
+* `pkgr install` will create test-library and install the following packages
+  - R6 (**user package**)
+  - pillar (**user package**)
+  - rlang (dependency)
+  - cli (dependency)
+  - utf8 (dependency)
+  - fansi (dependency)
+  - assertthat (dependency)
+  - crayon (dependency)

--- a/integration_tests/strict-mode/pkgr.yml
+++ b/integration_tests/strict-mode/pkgr.yml
@@ -1,0 +1,15 @@
+Version: 1
+
+# top level packages
+Packages:
+  - R6
+  - pillar
+
+# any repositories, order matters
+Repos:
+  - CRAN: "https://cran.microsoft.com/snapshot/2019-05-01"
+
+# Does not exist in this test case.
+Library: "test-library"
+
+Strict: true

--- a/integration_tests/threads/guide.md
+++ b/integration_tests/threads/guide.md
@@ -1,0 +1,16 @@
+# simple
+
+## Description
+Very simple pkgr environment meant to easily test the `threads` setting in pkgr.yml.
+
+## Expected Behaviors
+* `pkgr plan` will indicate that 5 threads are to be used.
+* `pkgr install` will install the following packages, launching five threads to do so:
+  - R6 (**user package**)
+  - pillar (**user package**)
+  - rlang (dependency)
+  - cli (dependency)
+  - utf8 (dependency)
+  - fansi (dependency)
+  - assertthat (dependency)
+  - crayon (dependency)

--- a/integration_tests/threads/guide.md
+++ b/integration_tests/threads/guide.md
@@ -1,4 +1,4 @@
-# simple
+# threads
 
 ## Description
 Very simple pkgr environment meant to easily test the `threads` setting in pkgr.yml.

--- a/integration_tests/threads/pkgr.yml
+++ b/integration_tests/threads/pkgr.yml
@@ -9,6 +9,6 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.rstudio.com"
+  - CRAN: "https://cran.microsoft.com/snapshot/2019-05-01"
 
 Library: "test-library"

--- a/integration_tests/threads/pkgr.yml
+++ b/integration_tests/threads/pkgr.yml
@@ -1,0 +1,14 @@
+Version: 1
+
+threads: 5
+
+# top level packages
+Packages:
+  - R6
+  - pillar
+
+# any repositories, order matters
+Repos:
+  - CRAN: "https://cran.rstudio.com"
+
+Library: "test-library"

--- a/pacman/utils.go
+++ b/pacman/utils.go
@@ -18,7 +18,7 @@ func GetPriorInstalledPackages(fileSystem afero.Fs, libraryPath string) map[stri
 	installedLibrary, err := fileSystem.Open(libraryPath)
 
 	if err != nil {
-		log.WithField("libraryPath", libraryPath).Fatal("package library not found at given library path")
+		log.WithField("libraryPath", libraryPath).Warn("package library not found at given library path")
 		return installed
 	}
 	defer installedLibrary.Close()

--- a/rcmd/install.go
+++ b/rcmd/install.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/spf13/viper"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -394,10 +393,7 @@ func InstallPackagePlan(
 	shouldInstall := make(chan string)
 	anyFailed := false
 
-	toInstall := plan.GetNumPackagesToInstall(viper.GetBool("update"))
-	//alreadyInstalled := len(plan.InstalledPackages)
-	packagesNeeded := toInstall //- alreadyInstalled
-	// numSuccesses := 0
+	packagesNeeded := plan.GetNumPackagesToInstall()
 
 	iDeps := plan.InvertDependencies()
 
@@ -423,9 +419,9 @@ func InstallPackagePlan(
 					packagesNeeded = packagesNeeded - 1
 					log.WithFields(log.Fields{
 						"package": iu.Package,
-						"package version": pkg.Metadata.Package.Version,
-						"package repo":    pkg.Metadata.Config.Repo.Name,
-						"pkgs remaining": packagesNeeded,
+						"version": pkg.Metadata.Package.Version,
+						"repo":    pkg.Metadata.Config.Repo.Name,
+						"remaining": packagesNeeded,
 					}).Info("Successfully Installed.")
 				}
 				installedPkgs[iu.Package] = true

--- a/rcmd/install_test.go
+++ b/rcmd/install_test.go
@@ -39,6 +39,10 @@ func TestInstallArgs(t *testing.T) {
 	}
 }
 
+// ATTENTION:
+// This test is misconfigured, it shouldn't be pointing to the integration test folders as those folders are only valid
+// after make test-install has been run from the integration_tests folder.
+// This test might fail falsey depending on the current state of pkgr/integration_tests/simple/test-library
 func TestUpdateDcfFile(t *testing.T) {
 	var tests = []struct {
 		filename     string

--- a/rcmd/worker.go
+++ b/rcmd/worker.go
@@ -63,18 +63,18 @@ func NewInstallQueue(n int,
 		ir InstallRequest,
 		pc PackageCache) (CmdResult, string, error),
 	updateFunc func(InstallUpdate)) *InstallQueue {
-	wq := make(chan InstallRequest, 2000)
-	uq := make(chan InstallUpdate, 500)
-	iq := InstallQueue{
-		WorkQueue:   wq,
-		UpdateQueue: uq,
+		wq := make(chan InstallRequest, 2000)
+		uq := make(chan InstallUpdate, 500)
+		iq := InstallQueue{
+			WorkQueue:   wq,
+			UpdateQueue: uq,
+		}
+		for i := 0; i < n; i++ {
+			iq.RegisterNewWorker(i+1, installFunc)
+		}
+		go iq.HandleUpdates(updateFunc)
+		return &iq
 	}
-	for i := 0; i < n; i++ {
-		iq.RegisterNewWorker(i+1, installFunc)
-	}
-	go iq.HandleUpdates(updateFunc)
-	return &iq
-}
 
 // HandleUpdates handles updates
 func (i *InstallQueue) HandleUpdates(fn func(InstallUpdate)) {

--- a/rollback/operations.go
+++ b/rollback/operations.go
@@ -13,6 +13,19 @@ func RollbackPackageEnvironment(fileSystem afero.Fs, rbp RollbackPlan) error {
 	//reset packages
 	logrus.Trace("Resetting package environment")
 
+	if rbp.InstallPlan.CreateLibrary {
+		err0 := fileSystem.RemoveAll(rbp.Library)
+
+		if err0 != nil {
+			logrus.WithFields(logrus.Fields{
+				"library": rbp.Library,
+			}).Warn("failed to remove created library during rollback", err0)
+			return err0
+		}
+
+		return nil
+	}
+
 	for _, pkg := range rbp.NewPackages {
 		err1 := fileSystem.RemoveAll(filepath.Join(rbp.Library, pkg))
 		if err1 != nil {

--- a/rollback/operations.go
+++ b/rollback/operations.go
@@ -19,7 +19,8 @@ func RollbackPackageEnvironment(fileSystem afero.Fs, rbp RollbackPlan) error {
 		if err0 != nil {
 			logrus.WithFields(logrus.Fields{
 				"library": rbp.Library,
-			}).Warn("failed to remove created library during rollback", err0)
+				"error": err0,
+			}).Warn("failed to remove created library during rollback")
 			return err0
 		}
 


### PR DESCRIPTION
Addresses the following issues: 
#173 - Library should be created if it doesn't exist
#170 - Cap threads to 8 when not specified
#171 - List number of remaining packages in install messages
#126 - Improve error messages when pkgr.yml not specified properly
