### PR TITLE
fix: osx R 4.0 url

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ import (
 )
 
 // VERSION is the current pkgr version
-var VERSION = "1.0.1"
+var VERSION = "1.0.2"
 
 
 var fs afero.Fs

--- a/cran/download-package.go
+++ b/cran/download-package.go
@@ -153,7 +153,7 @@ func DownloadPackage(fs afero.Fs, d PkgDl, dest string, rv RVersion) (Download, 
 	} else {
 		pkgdl = fmt.Sprintf("%s/bin/%s/contrib/%s/%s",
 			strings.TrimSuffix(d.Config.Repo.URL, "/"),
-			cranBinaryURL(),
+			cranBinaryURL(rv),
 			rv.ToString(),
 			filepath.Base(dest))
 	}

--- a/cran/repodb.go
+++ b/cran/repodb.go
@@ -92,7 +92,7 @@ func GetPackagesFileURL(r RepoURL, st SourceType, rv RVersion) string {
 		return fmt.Sprintf("%s/src/contrib/PACKAGES", strings.TrimSuffix(r.URL, "/"))
 		// TODO: fix so isn't hard coded to 3.5 binaries
 	}
-	return fmt.Sprintf("%s/bin/%s/contrib/%s/PACKAGES", strings.TrimSuffix(r.URL, "/"), cranBinaryURL(), rv.ToString())
+	return fmt.Sprintf("%s/bin/%s/contrib/%s/PACKAGES", strings.TrimSuffix(r.URL, "/"), cranBinaryURL(rv), rv.ToString())
 }
 
 // FetchPackages gets the packages for  RepoDb

--- a/cran/utils.go
+++ b/cran/utils.go
@@ -63,9 +63,12 @@ func SupportsCranBinary() bool {
 		return false
 	}
 }
-func cranBinaryURL() string {
+func cranBinaryURL(rv RVersion) string {
 	switch runtime.GOOS {
 	case "darwin":
+		if rv.Major == 4 {
+			return "macosx"
+		}
 		return "macosx/el-capitan"
 	case "windows":
 		return "windows"


### PR DESCRIPTION
osx 4.0 cran now drops el-capitan part of path

closes: #264