### PR TITLE
fix: altering NewRepoDb function to use separate conditions for CRAN-…

### DIFF
--- a/cran/repodb.go
+++ b/cran/repodb.go
@@ -31,7 +31,9 @@ func NewRepoDb(url RepoURL, dst SourceType, rc RepoConfig, rv RVersion) (*RepoDb
 		repoDatabasePointer.DefaultSourceType = rc.DefaultSourceType
 	}
 
-	if SupportsCranBinary() && rc.RepoType == MPN {
+	if SupportsCranBinary() { //&& rc.RepoType == MPN {
+		repoDatabasePointer.DescriptionsBySourceType[Binary] = make(map[string]desc.Desc)
+	} else if linuxSupportsBinary() && rc.RepoType == MPN {
 		repoDatabasePointer.DescriptionsBySourceType[Binary] = make(map[string]desc.Desc)
 	}
 

--- a/cran/utils.go
+++ b/cran/utils.go
@@ -65,11 +65,12 @@ func SupportsCranBinary() bool {
 	case "windows":
 		return true
 	case "linux":
-		if linuxSupportsBinary() {
-			return true
-		} else {
-			return false
-		}
+		return false // CRAN does not support linux binaries.
+		//if linuxSupportsBinary() {
+		//	return true
+		//} else {
+		//	return false
+		//}
 	default:
 		return false
 	}
@@ -148,13 +149,13 @@ func ReadOsRelease() {
 	vp.SetConfigType("toml")
 	err = vp.ReadConfig(bytes.NewReader(fixedConfig))
 	if err != nil {
-		log.Fatal("%v", err)
+		log.Fatalf("%v", err)
 	}
 
 	err = vp.Unmarshal(&osRelease)
 
 	if err != nil {
-		log.Fatal("%v\n", err)
+		log.Fatalf("%v\n", err)
 	}
 
 	// simplify this so it also works on EL distros


### PR DESCRIPTION
…binaries and Linux Binaries.

Also fixing a broken unit test.

## Problem
I ran into a bug where pkgr would not install binaries for R3.6 on MacOS (Mojave). After looking into it, I believe the changed in this PR is the culprit.

I have confirmed that the changes fix _my_ issue on Mac, but I have not yet re-tested the RepoType behavior.

Feel free to merge this PR or make your own version of the changes as you see fit!