### PR TITLE
METWORX-202 Strip conda from the front of the path if present

### DIFF
--- a/rcmd/configure.go
+++ b/rcmd/configure.go
@@ -55,6 +55,10 @@ func configureEnv(sysEnvVars []string, rs RSettings, pkg string) []string {
 				continue
 			}
 			if evs[0] == "PATH" {
+				condaPath := "/opt/anaconda/bin"
+				if strings.HasPrefix(evs[1], condaPath) && !rs.PreservePath {
+					evs[1] = strings.TrimPrefix(evs[1], fmt.Sprintf("%s:", condaPath))
+				}
 				rDir := filepath.Dir(rs.Rpath)
 				if rDir != "" && rDir != "." && !strings.HasPrefix(evs[1], rDir) {
 					evs[1] = fmt.Sprintf("%s:%s", rDir, evs[1])

--- a/rcmd/structs.go
+++ b/rcmd/structs.go
@@ -26,6 +26,7 @@ type RSettings struct {
 	GlobalEnvVars NvpList                      `json:"global_env_vars,omitempty"`
 	PkgEnvVars    map[string]map[string]string `json:"pkg_env_vars,omitempty"`
 	Platform      string                       `json:"platform,omitempty"`
+	PreservePath  bool                         `json:"preserve_path,omitempty"`
 }
 
 // InstallArgs represents the installation arguments R CMD INSTALL can consume


### PR DESCRIPTION
Since R uses its own compiler/linker configuration, we have the
option of modifying Renviron and Makeconf, but this is not a 100%
reliable solution for mitigating problems.

Conda ships more or less as a complete chroot including system
utilities, and its own version of many libraries. We should not
let Conda override this, so strip it from the path instead. For
configurability, add an option to let users preserve this
(possible that it will never be used, but it's there)