### PR TITLE
fix repository matching

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ import (
 )
 
 // VERSION is the current pkgr version
-var VERSION = "1.3.0"
+var VERSION = "1.3.1"
 
 var fs afero.Fs
 var cfg configlib.PkgrConfig

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ import (
 )
 
 // VERSION is the current pkgr version
-var VERSION = "1.2.0"
+var VERSION = "1.3.0"
 
 var fs afero.Fs
 var cfg configlib.PkgrConfig

--- a/rcmd/install.go
+++ b/rcmd/install.go
@@ -591,7 +591,7 @@ func updateDescriptionInfoByLines(lines []string, version, installType, repoURL,
 			continue
 		}
 
-		if strings.Contains(line, string("Repository:")) && !strings.Contains(line, repo) {
+		if strings.HasPrefix(line, "Repository:") && strings.TrimSpace(line) != strings.TrimSpace("Repository: "+ repo) {
 			originalRepo := strings.Trim(strings.Split(line, ":")[1], " ")
 			newLines = append(newLines, "OriginalRepository: "+originalRepo)
 			line = "Repository: " + repo


### PR DESCRIPTION
prior to fix, given a package with a respository field that was a superset of the repository in the pkgr.yml, it would not replace.

For example, PKPDmisc has `Repository: MPNDEV` in the source tarball so when installing from MPN the existing strings.Contains would still match true to `Repository: MPN` and not replace

```
Version: 1
Packages:
- PKPDmisc
  
Repos:
  - MPN: https://mpn.metworx.com/snapshots/stable/2020-08-15/

Lockfile:
    Type: renv

```

```
Package: PKPDmisc
Type: Package
Title: Pharmacokinetic and Pharmacodynamic Data Management Functions
Version: 3.0.0
Date: 2020-06-25
Authors@R: c(
    person("Devin", "Pastoor",
    email = "devin.pastoor@gmail.com", role = c("aut", "cre")))
Description: A toolbox for data management common to pharmacokinetic and
  pharmacokinetic modeling and simulation, such as resampling,
  area-under-the-curve calculation, data chunking, custom csv
  output, and project scaffolding.
URL: https://github.com/metrumresearchgroup/PKPDmisc
BugReports: https://github.com/metrumresearchgroup/PKPDmisc/issues
Depends: R (>= 3.2.2)
LinkingTo: Rcpp, BH
Imports: dplyr (>= 0.5.0), data.table, ggplot2, lazyeval, magrittr,
        parallel, purrr, Rcpp (>= 0.12.10), readr (>= 1.0.0), rlang,
        stringr, tibble
Suggests: sessioninfo, knitr, rmarkdown, testthat
LazyData: TRUE
License: MIT + file LICENSE
VignetteBuilder: knitr
RoxygenNote: 7.1.0
Encoding: UTF-8 
Repository: MPNDEV
Origin: github.com/metrumresearchgroup/PKPDmisc
git_tag: 3.0.0
git_commit: a90d6edb6bc2a5de6a8d22797fdb88a3a1aa4032
NeedsCompilation: yes
Packaged: 2020-06-25 22:12:45 UTC; devinp
Author: Devin Pastoor [aut, cre]
Maintainer: Devin Pastoor <devin.pastoor@gmail.com>
Built: R 3.6.3; x86_64-apple-darwin15.6.0; 2020-06-27 17:28:47 UTC; unix
PkgrVersion: 1.3.0-2020-11-17T19:43:39-0500
PkgrInstallType: binary
PkgrRepositoryURL: https://mpn.metworx.com/snapshots/stable/2020-08-15/
```

vs 

```
Package: PKPDmisc
Type: Package
Title: Pharmacokinetic and Pharmacodynamic Data Management Functions
Version: 3.0.0
Date: 2020-06-25
Authors@R: c(
    person("Devin", "Pastoor",
    email = "devin.pastoor@gmail.com", role = c("aut", "cre")))
Description: A toolbox for data management common to pharmacokinetic and
  pharmacokinetic modeling and simulation, such as resampling,
  area-under-the-curve calculation, data chunking, custom csv
  output, and project scaffolding.
URL: https://github.com/metrumresearchgroup/PKPDmisc
BugReports: https://github.com/metrumresearchgroup/PKPDmisc/issues
Depends: R (>= 3.2.2)
LinkingTo: Rcpp, BH
Imports: dplyr (>= 0.5.0), data.table, ggplot2, lazyeval, magrittr,
        parallel, purrr, Rcpp (>= 0.12.10), readr (>= 1.0.0), rlang,
        stringr, tibble
Suggests: sessioninfo, knitr, rmarkdown, testthat
LazyData: TRUE
License: MIT + file LICENSE
VignetteBuilder: knitr
RoxygenNote: 7.1.0
Encoding: UTF-8
OriginalRepository: MPNDEV
Repository: MPN
Origin: github.com/metrumresearchgroup/PKPDmisc
git_tag: 3.0.0
git_commit: a90d6edb6bc2a5de6a8d22797fdb88a3a1aa4032
NeedsCompilation: yes
Packaged: 2020-06-25 22:12:45 UTC; devinp
Author: Devin Pastoor [aut, cre]
Maintainer: Devin Pastoor <devin.pastoor@gmail.com>
Built: R 3.6.3; x86_64-apple-darwin15.6.0; 2020-06-27 17:28:47 UTC; unix
PkgrVersion: 1.3.0-2020-11-17T19:43:39-0500
PkgrInstallType: binary
PkgrRepositoryURL: https://mpn.metworx.com/snapshots/stable/2020-08-15/
```

diff:


```diff
Package: PKPDmisc
...
Encoding: UTF-8
+OriginalRepository: MPNDEV
+Repository: MPN
-Repository: MPNDEV
Origin: github.com/metrumresearchgroup/PKPDmisc
git_tag: 3.0.0
...
```


