### PR TITLE
feat: simplify autoenv behavior

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ import (
 )
 
 // VERSION is the current pkgr version
-var VERSION = "1.3.1"
+var VERSION = "2.0.0"
 
 var fs afero.Fs
 var cfg configlib.PkgrConfig

--- a/configlib/config.go
+++ b/configlib/config.go
@@ -122,7 +122,7 @@ func loadConfigFromPath(configFilename string) error {
 		configFilename = "pkgr.yml"
 	}
 	viper.SetEnvPrefix("pkgr")
-	viper.AutomaticEnv()
+	viper.BindEnv("rpath", "library")
 	configFilename, _ = homedir.Expand(filepath.Clean(configFilename))
 	viper.SetConfigFile(configFilename)
 	b, err := ioutil.ReadFile(configFilename)


### PR DESCRIPTION
closes #319 

The two likely candidates for existing CI use by users are library and rpath. In general this should not impact people but is a breaking change to the user api, thus bumping the major version.