### PR TITLE
exp: allow for ignoring certain packages in the solve

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -108,7 +108,15 @@ func rInstall(cmd *cobra.Command, args []string) error {
 	//
 	// Install the packages
 	//
-	err = rcmd.InstallPackagePlan(fs, installPlan, pkgMap, packageCache, pkgInstallArgs, rSettings, rcmd.ExecSettings{PkgrVersion: VERSION}, nworkers)
+	err = rcmd.InstallPackagePlan(fs,
+		installPlan,
+		pkgMap,
+		packageCache,
+		pkgInstallArgs,
+		rSettings,
+		rcmd.ExecSettings{PkgrVersion: VERSION},
+		nworkers,
+	)
 
 	//
 	// Install the tarballs, if applicable.

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -158,6 +158,13 @@ func planInstall(rv cran.RVersion, exitOnMissing bool) (*cran.PkgNexus, gpsr.Ins
 	log.Infoln("Default package installation type: ", st.String())
 	for _, db := range pkgNexus.Db {
 		log.Infoln(fmt.Sprintf("%v:%v (binary:source) packages available in for %s from %s", len(db.DescriptionsBySourceType[cran.Binary]), len(db.DescriptionsBySourceType[cran.Source]), db.Repo.Name, db.Repo.URL))
+		for _, pkg := range cfg.IgnorePackages {
+			// to "skip" packages, we'll just completely nuke them from the pkgdb so they'll never even come up in the plan
+			// this is probably overly hacky
+			log.Debugln("ignoring by deleting pkg: ", pkg)
+			delete(db.DescriptionsBySourceType[cran.Binary], pkg)
+			delete(db.DescriptionsBySourceType[cran.Source], pkg)
+		}
 	}
 	log.Infoln("Package installation cache directory: ", userCache(cfg.Cache))
 	log.Infoln("Database cache directory: ", filepath.Dir(pkgNexus.Db[0].GetRepoDbCacheFilePath(rv.ToFullString())))

--- a/configlib/structs.go
+++ b/configlib/structs.go
@@ -42,6 +42,7 @@ type Lockfile struct {
 type PkgrConfig struct {
 	Version        int                 `yaml:"Version,omitempty"`
 	Packages       []string            `yaml:"Packages,omitempty"`
+	IgnorePackages   []string          `mapstructure:"ignore_packages,yaml:"ignore_packages,omitempty"`
 	Tarballs       []string            `yaml:"Tarballs,omitempty"`
 	Descriptions   []string            `yaml:"Descriptions,omitempty"`
 	Suggests       bool                `yaml:"Suggests,omitempty"`


### PR DESCRIPTION
this will currently rip them out of the dep tree, so an ignored package
and all its deps will be removed. This means if that package is part of
the required package set it will cause the solve to fail, however
when having some suggested deps that want to selectively exclude
can work well.