### PR TITLE
fix customization code

### DIFF
--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -68,10 +68,11 @@ func InitGlobalConfig(libraryPath, localRepo string, update, suggests bool, inst
 		//Logging: configlib.LogConfig{Level: "debug"}, // Controlled before cfg unmarshalling, I think
 		Cache: "./testsite/working/localcache",
 		Customizations: configlib.Customizations{
-			Repos: map[string]configlib.RepoConfig{
+			Repos: []map[string]configlib.RepoConfig{{
 				"testRepo": configlib.RepoConfig{
 					Type: installType,
 				},
+			},
 			},
 		},
 		//LibPaths: nil,
@@ -300,9 +301,11 @@ func TestInstallWithoutRollback(t *testing.T) {
 		//Logging: nil,
 		//Cache: nil,
 		Customizations: configlib.Customizations{
-			Repos: map[string]configlib.RepoConfig{
-				"local58": configlib.RepoConfig{
-					Type: "source",
+			Repos: []map[string]configlib.RepoConfig{
+				{
+					"local58": configlib.RepoConfig{
+						Type: "source",
+					},
 				},
 			},
 		},

--- a/cmd/pkgr/goreleaser.yml
+++ b/cmd/pkgr/goreleaser.yml
@@ -25,7 +25,7 @@ build:
 brews:
   # Repository to push the tap to.
   -
-    github:
-      owner: metrumresearchgroup
-      name: homebrew-tap
+    tap:
+      owner: metrumresearchgroup 
+      name: homebrew-tap 
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ import (
 )
 
 // VERSION is the current pkgr version
-var VERSION = "2.0.2"
+var VERSION = "3.0.0"
 
 var fs afero.Fs
 var cfg configlib.PkgrConfig

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"github.com/metrumresearchgroup/pkgr/configlib"
 	"github.com/metrumresearchgroup/pkgr/rcmd"
 
 	"github.com/spf13/cobra"
@@ -39,11 +40,9 @@ func rRun(cmd *cobra.Command, args []string) error {
 	// at least for experimentation for now. If necessary can refactor out the
 	// specifics so could be run here exactly.
 	rs.LibPaths = append(rs.LibPaths, cfg.Library)
-	pc := cfg.Customizations.Packages
-	for n, v := range pc {
-		if v.Env != nil {
-			rs.PkgEnvVars[n] = v.Env
-		}
+	pc, exists := configlib.GetPackageCustomizationByName(pkg, cfg.Customizations)
+	if exists {
+		rs.PkgEnvVars[pkg] = pc.Env
 	}
 	rcmd.StartR(fs, pkg, rs, "")
 	return nil

--- a/configlib/config.go
+++ b/configlib/config.go
@@ -230,10 +230,12 @@ func remove(ymlfile string, packageName string) error {
 
 // SetCustomizations ... set ENV values in Rsettings
 func SetCustomizations(rSettings rcmd.RSettings, cfg PkgrConfig) rcmd.RSettings {
-	pkgCustomizations := cfg.Customizations.Packages
-	for n, v := range pkgCustomizations {
-		if v.Env != nil {
-			rSettings.PkgEnvVars[n] = v.Env
+	pkgCustomizationsSlice := cfg.Customizations.Packages
+	for _, pkgCustomizations := range pkgCustomizationsSlice {
+		for n, v := range pkgCustomizations {
+			if v.Env != nil {
+				rSettings.PkgEnvVars[n] = v.Env
+			}
 		}
 	}
 	return rSettings
@@ -263,28 +265,31 @@ func setCfgCustomizations(cfg PkgrConfig, dependencyConfigurations *gpsr.Install
 }
 
 func setViperCustomizations(cfg PkgrConfig, pkgSettings []interface{}, dependencyConfigurations gpsr.InstallDeps, pkgNexus *cran.PkgNexus) {
-	for pkg, v := range cfg.Customizations.Packages {
-		if IsCustomizationSet("Suggests", pkgSettings, pkg) {
-			pkgDepTypes := dependencyConfigurations.Default
-			pkgDepTypes.Suggests = v.Suggests
-			dependencyConfigurations.Deps[pkg] = pkgDepTypes
-		}
-		if IsCustomizationSet("Repo", pkgSettings, pkg) {
-			err := pkgNexus.SetPackageRepo(pkg, v.Repo)
-			if err != nil {
-				log.WithFields(log.Fields{
-					"pkg":  pkg,
-					"repo": v.Repo,
-				}).Fatal("error finding custom repo to set")
+	pkgCustomizationsSlice := cfg.Customizations.Packages
+	for _, pkgCustomizations := range pkgCustomizationsSlice {
+		for pkg, v := range pkgCustomizations {
+			if IsCustomizationSet("Suggests", pkgSettings, pkg) {
+				pkgDepTypes := dependencyConfigurations.Default
+				pkgDepTypes.Suggests = v.Suggests
+				dependencyConfigurations.Deps[pkg] = pkgDepTypes
 			}
-		}
-		if IsCustomizationSet("Type", pkgSettings, pkg) {
-			err := pkgNexus.SetPackageType(pkg, v.Type)
-			if err != nil {
-				log.WithFields(log.Fields{
-					"pkg":  pkg,
-					"repo": v.Repo,
-				}).Fatal("error finding custom repo to set")
+			if IsCustomizationSet("Repo", pkgSettings, pkg) {
+				err := pkgNexus.SetPackageRepo(pkg, v.Repo)
+				if err != nil {
+					log.WithFields(log.Fields{
+						"pkg":  pkg,
+						"repo": v.Repo,
+					}).Fatal("error finding custom repo to set")
+				}
+			}
+			if IsCustomizationSet("Type", pkgSettings, pkg) {
+				err := pkgNexus.SetPackageType(pkg, v.Type)
+				if err != nil {
+					log.WithFields(log.Fields{
+						"pkg":  pkg,
+						"repo": v.Repo,
+					}).Fatal("error finding custom repo to set")
+				}
 			}
 		}
 	}

--- a/configlib/get_customization.go
+++ b/configlib/get_customization.go
@@ -1,0 +1,29 @@
+package configlib
+
+// GetRepoCustomizationByName will return a Repository customization by name as well
+// as whether it exists. This is helpful given the customization config of array of maps
+// makes it more annoying than it should be to get one.
+func GetRepoCustomizationByName(nm string, c Customizations) (RepoConfig, bool){
+	for _, rc := range c.Repos {
+		rv, ok := rc[nm]
+		if !ok {
+			continue
+		}
+		return rv, true
+	}
+	return RepoConfig{}, false
+}
+
+// GetPackageCustomizationByName will return a Package customization by name as well
+// as whether it exists. This is helpful given the customization config of array of maps
+// makes it more annoying than it should be to get one.
+func GetPackageCustomizationByName(nm string, c Customizations) (PkgConfig, bool){
+	for _, rc := range c.Packages {
+		rv, ok := rc[nm]
+		if !ok {
+			continue
+		}
+		return rv, true
+	}
+	return PkgConfig{}, false
+}

--- a/configlib/get_customization_test.go
+++ b/configlib/get_customization_test.go
@@ -20,7 +20,6 @@ func TestGetPackageCustomizationByName(t *testing.T) {
 		want  PkgConfig
 		want1 bool
 	}{
-		// TODO: Add test cases.
 		{
 			name: "no customization",
 			args: args{

--- a/configlib/get_customization_test.go
+++ b/configlib/get_customization_test.go
@@ -1,0 +1,112 @@
+package configlib
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetPackageCustomizationByName(t *testing.T) {
+	// just enough config to confirm its not a default struct
+	dplyrPkg := PkgConfig{
+		Suggests: true,
+	}
+	type args struct {
+		nm string
+		c  Customizations
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  PkgConfig
+		want1 bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "no customization",
+			args: args{
+				nm: "dplyr",
+				c:  Customizations{},
+			},
+			want:  PkgConfig{},
+			want1: false,
+		},
+		{
+			name: "has customization",
+			args: args{
+				nm: "dplyr",
+				c: Customizations{
+					Packages: []map[string]PkgConfig{
+						{
+							"dplyr": dplyrPkg,
+						},
+					},
+				},
+			},
+			want:  dplyrPkg,
+			want1: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetPackageCustomizationByName(tt.args.nm, tt.args.c)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetPackageCustomizationByName() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetPackageCustomizationByName() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestGetRepoCustomizationByName(t *testing.T) {
+	mpnRepo := RepoConfig{
+		RepoSuffix: "SomeValue",
+	}
+	type args struct {
+		nm string
+		c  Customizations
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  RepoConfig
+		want1 bool
+	}{
+		{
+			name: "no customization",
+			args: args{
+				nm: "MPN",
+				c:  Customizations{},
+			},
+			want:  RepoConfig{},
+			want1: false,
+		},
+		{
+			name: "with customization",
+			args: args{
+				nm: "MPN",
+				c: Customizations{
+					Repos: []map[string]RepoConfig{
+						{
+							"MPN": mpnRepo,
+						},
+					},
+				},
+			},
+			want:  mpnRepo,
+			want1: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetRepoCustomizationByName(tt.args.nm, tt.args.c)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetRepoCustomizationByName() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetRepoCustomizationByName() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/configlib/structs.go
+++ b/configlib/structs.go
@@ -29,8 +29,8 @@ type LogConfig struct {
 
 // Customizations contains various custom configurations
 type Customizations struct {
-	Packages map[string]PkgConfig  `yaml:"Packages,omitempty"`
-	Repos    map[string]RepoConfig `yaml:"Repos,omitempty"`
+	Packages []map[string]PkgConfig  `yaml:"Packages,omitempty"`
+	Repos    []map[string]RepoConfig `yaml:"Repos,omitempty"`
 }
 
 // Lockfile struct hold values for packrat lockfile support


### PR DESCRIPTION
One of the more subtle bugs that has emerged is due to the fact that viper is a bit loose around how it unmarshals, when combined with some interface{} related flexible code meant that when needing a structure that actually mapped to the actual expected config more explicitly, some failures occured.

In particular, with the add/remove commands, explicit yaml unmarshalling vs viper was used and was getting parsing errors in the yaml. This actually showed that the exisitng underlying struct vs the user specification was off. This has now been fixed, but also showed where a different underlying structure has been used throughout the code.

Namely, as a user customizations are specified as arrays:

```
Packages:
- dplyr:
    Suggests: true
- ggplot2:
    Repo: something
```

This structure is a slice of map[string], however within the code where just using a map structure directly. 

The code changes here fix the underlying structures to the user spec and fix the resulting code.