### PR TITLE
combined install output

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -354,7 +354,7 @@ func logUserPackageRepos(packageDownloads []cran.PkgDl) {
 			"repo":         pkg.Config.Repo.Name,
 			"type":         pkg.Config.Type,
 			"version":      pkg.Package.Version,
-			"relationship": "user package",
+			"relationship": "user_defined",
 		}).Debug("package repository set")
 	}
 }

--- a/integration_tests/simple/pkgr.yml
+++ b/integration_tests/simple/pkgr.yml
@@ -3,10 +3,15 @@ Version: 1
 Packages:
   - R6
   - pillar
-
+  - Rcpp
 # any repositories, order matters
 Repos:
-  - CRAN: "https://mpn.metworx.com/snapshots/stable/2020-11-21"
+  - CRAN: "https://mpn.metworx.com/snapshots/stable/2021-06-20"
 
 
 Library: "test-library"
+
+Customizations:
+  Repos:
+  - CRAN:
+      Type: source

--- a/rcmd/structs.go
+++ b/rcmd/structs.go
@@ -7,6 +7,7 @@ import (
 
 // CmdResult stores information about the executed cmd
 type CmdResult struct {
+	Output   string `json:output,omitempty`
 	Stdout   string `json:"stdout,omitempty"`
 	Stderr   string `json:"stderr,omitempty"`
 	ExitCode int    `json:"exit_code,omitempty"`


### PR DESCRIPTION
This PR provides a combined output structure instead of separated stdout and stderror streams (though we also retained the separated version internally and for trace level output.

This was a pain point for diagnosing as during installation many pieces swap back and forth printing to stdout or stderr so trying to actually read a linear set of messages to understand how the install proceeded was basically impossible. This is especially so for packages with c++ code that the compilation output gets emitted