### PR TITLE
add version flags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,6 +19,16 @@ steps:
     volumes:
       - name: go
         path: /go
+  - name: baseline
+    image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci:4.1.0
+    pull: never
+    volumes:
+      - name: go
+        path: /go
+    commands:
+      - export PATH=/go/bin:$PATH
+      - cd integration_tests/baseline
+      - make test
   - name: version
     image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci:4.1.0
     pull: never

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,9 +1,38 @@
+---
 kind: pipeline
 type: docker
-name: default
-
+name: integration-tests
 steps:
-- name: test
-  image: evol262/pkgr
-  commands:
-  - make test-mixed
+  - name: pull
+    image: omerxx/drone-ecr-auth
+    commands:
+      - $(aws ecr get-login --no-include-email --region us-east-1)
+      - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci:4.1.0
+    volumes:
+      - name: docker.sock
+        path: /var/run/docker.sock
+  - name: build
+    image: golang:1.16
+    commands:
+      - make install
+      - go get ./...
+    volumes:
+      - name: go
+        path: /go
+  - name: version
+    image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci:4.1.0
+    pull: never
+    volumes:
+      - name: go
+        path: /go
+    commands:
+      - export PATH=/go/bin:$PATH
+      - cd integration_tests/version
+      - make test
+
+volumes:
+  - name: docker.sock
+    host:
+      path: /var/run/docker.sock
+  - name: go
+    temp: { }

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 BUILD=`date +%FT%T%z`
-LDFLAGS=-ldflags "-X main.buildTime=${BUILD}"
 MAKE_HOME=${PWD}
 TEST_HOME=${MAKE_HOME}/integration_tests
 
 .PHONY: all ci clean install simple test-multiple log-test log-test-reset test-master test-master-reset test-mixed test-mixed-reset
 
 install:
-	cd cmd/pkgr; go get; go install ${LDFLAGS}
+	cd cmd/pkgr; go get; go install
 
+build:
+	cd cmd/pkgr; goreleaser build --snapshot --rm-dist --single-target
 all: install test-simple
 
 ci: install test-mixed

--- a/cmd/pkgr/goreleaser.yml
+++ b/cmd/pkgr/goreleaser.yml
@@ -7,6 +7,32 @@ release:
   # If set to true, will mark the release as not ready for production.
   # Default is false.
   prerelease: auto
+  footer: |
+    ## Installation Instructions
+
+    ### Mac
+
+    first time:
+
+    ```
+    brew tap metrumresearchgroup/tap
+    brew install pkgr
+    ```
+
+    upgrade:
+
+    ```
+    brew upgrade pkgr
+    ```
+
+    ### Linux
+
+    ```
+    sudo wget https://github.com/metrumresearchgroup/pkgr/releases/{{ .Tag }}/{{ .ArtifactName }} -O /tmp/pkgr.tar.gz
+    sudo tar xzf /tmp/pkgr.tar.gz pkgr
+    sudo mv pkgr /usr/local/bin/pkgr
+    sudo chmod +x /usr/local/bin/pkgr
+    ```
 
 build:
   binary: pkgr

--- a/cmd/pkgr/pkgr.go
+++ b/cmd/pkgr/pkgr.go
@@ -4,9 +4,6 @@ import (
 	"github.com/metrumresearchgroup/pkgr/cmd"
 )
 
-// buildTime  can be set from LDFLAGS during development
-var buildTime string
-
 // if want to generate docs
 //	import "github.com/spf13/cobra/doc"
 //	err := doc.GenMarkdownTree(cmd.RootCmd, "../../docs/bbi")
@@ -14,5 +11,5 @@ var buildTime string
 //		panic(err)
 //	}
 func main() {
-	cmd.Execute(buildTime)
+	cmd.Execute()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -28,24 +29,25 @@ import (
 	"github.com/metrumresearchgroup/pkgr/logger"
 )
 
-// VERSION is the current pkgr version
-var VERSION = "3.0.0"
+// version should be injected at build time, if completely development version will just give a timestamp
+var VERSION = "dev-" + time.Now().String()
 
 var fs afero.Fs
 var cfg configlib.PkgrConfig
+var printVersion bool
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "pkgr",
 	Short: "package manager",
+	Version: VERSION,
 }
+
 
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute(build string) {
-	if build != "" {
-		VERSION = fmt.Sprintf("%s-%s", VERSION, build)
-	}
+func Execute() {
+	RootCmd.SetVersionTemplate(VERSION)
 	RootCmd.Long = fmt.Sprintf("pkgr cli version %s", VERSION)
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -63,6 +65,8 @@ func rootInit() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports Persistent Flags, which, if defined here,
 	// will be global for your application.
+	RootCmd.Flags().BoolVarP(&printVersion, "version", "v", false, "print the version")
+
 	RootCmd.PersistentFlags().String("config", "", "config file (default is pkgr.yml)")
 	_ = viper.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config"))
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,21 +16,19 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
-	"time"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"os"
+	"path/filepath"
 
 	"github.com/metrumresearchgroup/pkgr/configlib"
 	"github.com/metrumresearchgroup/pkgr/logger"
 )
 
 // version should be injected at build time, if completely development version will just give a timestamp
-var VERSION = "dev-" + time.Now().String()
+var VERSION = "dev"
 
 var fs afero.Fs
 var cfg configlib.PkgrConfig

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,6 @@ github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaW
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/metrumresearchgroup/command v0.0.1 h1:GKOmZN7jIQALPtVQ9g3dx+o8IkpUaXceE/keunP36NQ=
-github.com/metrumresearchgroup/command v0.0.1/go.mod h1:RN0GpeHtPOEpPGT7LrXrxsfzHr4Q8sbFZvpRlV20mys=
 github.com/metrumresearchgroup/command v0.0.2-0.20210716145028-d3194efebb33 h1:mWlNMsqkEIKU2qMwwm1MnRAb8ZQLgERazUZY7BfrMX0=
 github.com/metrumresearchgroup/command v0.0.2-0.20210716145028-d3194efebb33/go.mod h1:RN0GpeHtPOEpPGT7LrXrxsfzHr4Q8sbFZvpRlV20mys=
 github.com/mholt/archiver/v3 v3.5.0 h1:nE8gZIrw66cu4osS/U7UW7YDuGMHssxKutU8IfWxwWE=

--- a/integration_tests/baseline/Makefile
+++ b/integration_tests/baseline/Makefile
@@ -1,10 +1,11 @@
 TEST_HOME=${PWD}
 
-.PHONY: clean
+.PHONY: clean update test test-json
 
 clean:
 	rm -rf test-library
 	rm -rf test-cache
+	go clean -testcache
 
 update: clean
 	go test ./... -update

--- a/integration_tests/integration_helper/runt.go
+++ b/integration_tests/integration_helper/runt.go
@@ -35,7 +35,7 @@ func RunTest(tgt targets.Target) error {
 		return err
 	}
 
-	if strings.Contains(r.Output, "FAIL:") {
+	if strings.Contains(string(r.Output), "FAIL:") {
 		return errors.New("found FAIL message")
 	}
 

--- a/integration_tests/version/.gitignore
+++ b/integration_tests/version/.gitignore
@@ -1,0 +1,2 @@
+test-library
+test-cache

--- a/integration_tests/version/Makefile
+++ b/integration_tests/version/Makefile
@@ -1,0 +1,16 @@
+TEST_HOME=${PWD}
+
+.PHONY: clean
+
+clean:
+	rm -rf test-library
+	rm -rf test-cache
+
+update: clean
+	go test ./... -update
+
+test: clean
+	go test ./... -v
+
+test-json: clean
+	go test ./... -json

--- a/integration_tests/version/Makefile
+++ b/integration_tests/version/Makefile
@@ -1,6 +1,6 @@
 TEST_HOME=${PWD}
 
-.PHONY: clean
+.PHONY: clean update test test-json
 
 clean:
 	go clean -testcache

--- a/integration_tests/version/Makefile
+++ b/integration_tests/version/Makefile
@@ -3,8 +3,7 @@ TEST_HOME=${PWD}
 .PHONY: clean
 
 clean:
-	rm -rf test-library
-	rm -rf test-cache
+	go clean -testcache
 
 update: clean
 	go test ./... -update

--- a/integration_tests/version/guide.md
+++ b/integration_tests/version/guide.md
@@ -1,0 +1,6 @@
+# version 
+
+## Description
+Check that the version flags `-v` and `--version` return version information
+
+

--- a/integration_tests/version/version_test.go
+++ b/integration_tests/version/version_test.go
@@ -17,7 +17,7 @@ func TestVersion(t *testing.T) {
 			t.Fatal(err)
 		}
 		// this will always get the git tag for regular releases
-		assert.Contains(t, string(res.Output), "dev-")
+		assert.Equal(t, "dev", string(res.Output))
 	})
 
 	t.Run("short flag -v works", func(t *testing.T) {
@@ -26,7 +26,7 @@ func TestVersion(t *testing.T) {
 			t.Fatal(err)
 		}
 		// this will always get the git tag for regular releases
-		assert.Contains(t, string(res.Output), "dev-")
+		assert.Equal(t,"dev",  string(res.Output))
 	})
 
 }

--- a/integration_tests/version/version_test.go
+++ b/integration_tests/version/version_test.go
@@ -1,0 +1,32 @@
+package version_test
+
+import (
+	"context"
+	"github.com/metrumresearchgroup/command"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	testCmd := command.New()
+	ctx := context.TODO()
+
+	t.Run("long flag --version works", func(t *testing.T) {
+		res, err := testCmd.Run(ctx, "pkgr", "--version")
+		if err != nil {
+			t.Fatal(err)
+		}
+		// this will always get the git tag for regular releases
+		assert.Contains(t, string(res.Output), "dev-")
+	})
+
+	t.Run("short flag -v works", func(t *testing.T) {
+		res, err := testCmd.Run(ctx, "pkgr", "--version")
+		if err != nil {
+			t.Fatal(err)
+		}
+		// this will always get the git tag for regular releases
+		assert.Contains(t, string(res.Output), "dev-")
+	})
+
+}


### PR DESCRIPTION
This PR adds `--version` and `-v` flags

```
pkgr --version
pkgr -v
```

which will return the injected build tag for any published release - eg. v3.0.1

