### PR TITLE
remove extra space in log message

### DIFF
--- a/cran/download-package.go
+++ b/cran/download-package.go
@@ -188,7 +188,7 @@ func DownloadPackage(fs afero.Fs, d PkgDl, dest string, rv RVersion, noSecure bo
 	}
 	log.Trace(pkgdl)
 
-	log.WithField("package", d.Package.Package).Info("downloading package ")
+	log.WithField("package", d.Package.Package).Info("downloading package")
 	var from io.ReadCloser
 
 	client := &http.Client{}


### PR DESCRIPTION
There is what appears to be an extra space in the log message for "downloading package".  If it's intentional, no worries about closing this.