### PR TITLE
Prepare v3.1.0 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,19 @@
+
+# pkgr 3.0.0
+
+This release is primarily about adding a more robust test suite, with
+minimal user-facing changes. One notable exception is the first point
+below, relating to the new `--no-update` flag.
+
+* Reversed default behavior to update to newest available versions of
+  packages when `pkgr install` is run, unless `--no-update` flag is
+  present (305a8353). Previously `pkgr` did _not_ update installed
+  packages unless `--update` was passed.
+
+* Add explicit version flag (6dd9c3ee).
+
+* Added `IgnorePackages` to ignore specific packages from being
+  installed even if they're in the dependency tree (104f1c9c).
+
+* Extend integration test coverage and refactored test suite to
+  position better for future changes.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,18 @@
 
+# pkgr 3.1.0
+
+* For `Lockfile: Type: renv`, pkgr now invokes `renv` to discover the
+  library location rather than assuming it is under the current
+  directory's `renv/library/`. This change is important for
+  compatibility with renv 0.15 and later, where the default behavior
+  is now to put a _package_ project library outside of the main
+  project directory. (#396)
+
+* System CPU quotas are now respected when setting the number of CPUs
+  that are used if the `--threads` option isn't explicitly passed and
+  the `GOMAXPROCS` environment variable isn't set. (#385)
+
+
 # pkgr 3.0.0
 
 This release is primarily about adding a more robust test suite, with


### PR DESCRIPTION
This PR adds a NEWS.md file with

  * Seth's [release notes for v3.0.0](https://github.com/metrumresearchgroup/pkgr/releases/tag/v3.0.0)

  * release notes for the next release, v3.1.0

I think keeping these release notes in the repo is a good idea given the plan is to prepare them for releases anyway, but I don't have strong preferences on the name of the file or other specifics.

changeset: https://github.com/metrumresearchgroup/pkgr/compare/bccaa523f7df3cd64e0534a0607953da96ddaa4b...e24ccac52d5313b3c715604e6f01e90c70463c5b
