### PR TITLE
config: mark renv library path for more reliable detection

### DIFF
--- a/integration_tests/bad-customization/bad_customization_test.go
+++ b/integration_tests/bad-customization/bad_customization_test.go
@@ -24,6 +24,10 @@ func TestBadCustomization(t *testing.T) {
 
 		logs := CollectGenericLogs(t, capture, "error finding custom repo to set")
 		assert.Len(t, logs, 1)
+		if len(logs) == 0 {
+			t.Fatalf("CollectGenericLogs() unexpectedly returned no results")
+		}
+
 		errorMessage := logs[0]
 		assert.Equal(t, "R6", errorMessage.Pkg)
 		assert.Equal(t, "DoesNotExist", errorMessage.Repo)

--- a/integration_tests/bad-customization/pkgr.yml
+++ b/integration_tests/bad-customization/pkgr.yml
@@ -5,7 +5,7 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.microsoft.com/snapshot/2020-05-01"
+  - MPN: "https://mpn.metworx.com/snapshots/stable/2023-05-14"
 
 Library: "test-library"
 

--- a/integration_tests/library/libraries_test.go
+++ b/integration_tests/library/libraries_test.go
@@ -144,7 +144,7 @@ func TestLibraryRenv(t *testing.T) {
 		}
 
 		err = os.WriteFile(filepath.Join("pkg", ".Rprofile"),
-			[]byte("source(\"renv/activate.R\")\n"),
+			[]byte("cat('i do not interfere\n')\nsource('renv/activate.R')\n"),
 			0666)
 		if err != nil {
 			t.Fatalf("os.WriteFile() error: %s", err)


### PR DESCRIPTION
The last commit of fixes renv detection when other code startup code writes to stdout.  I hit into a case in the wild where someone's .Rprofile `cat` some text, leading to `pkgr` aborting because it received more than one line on stdout.  (Cases that use `message` don't hit into this because that writes to stderr.)

Demo:

```
$ head -1 .Rprofile
cat("bah\n")

$ pkgr plan
WARN[0000] expected one line for renv library, got 2:
 ["bah" "/data/home/kylem/src/github/metrumresearchgroup/nmrec/renv/library/R-4.1/x86_64-pc-linux-gnu"]
FATA[0000] Lockfile type is renv, but calling renv to find library path failed.
Check that renv is installed or consider using `Library:` instead.
```

The first two patches clean up an unrelated test failure that I noticed when pushing this branch.  It looks like it's due to a dead https://cran.microsoft.com link.
