### PR TITLE
tests: update for MRAN retirement

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -66,6 +66,28 @@ steps:
       - export PKGR_TESTS_SYS_RENV=1
       - cd configlib
       - go test -v .
+  - name: gpsr
+    image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci:4.1.0
+    pull: never
+    volumes:
+      - name: go
+        path: /go
+    environment:
+      <<: *default_environment
+    commands:
+      - cd gpsr
+      - go test -v .
+  - name: cran
+    image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci:4.1.0
+    pull: never
+    volumes:
+      - name: go
+        path: /go
+    environment:
+      <<: *default_environment
+    commands:
+      - cd cran
+      - go test -v .
   - name: baseline
     image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci:4.1.0
     pull: never

--- a/configlib/config_test.go
+++ b/configlib/config_test.go
@@ -302,7 +302,7 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.microsoft.com/snapshot/2020-05-01"
+  - MPN: "https://mpn.metworx.com/snapshots/stable/2023-06-29"
 
 
 Library: "test-library"
@@ -994,7 +994,7 @@ func TestNewConfigSimple(t *testing.T) {
 	assert.Equal(t, false, cfg.NoUpdate)
 	assert.Equal(t, false, cfg.Suggests)
 	assert.Empty(t, cfg.Customizations)
-	assert.Equal(t, []map[string]string{{"CRAN": "https://cran.microsoft.com/snapshot/2020-05-01"}}, cfg.Repos)
+	assert.Equal(t, []map[string]string{{"MPN": "https://mpn.metworx.com/snapshots/stable/2023-06-29"}}, cfg.Repos)
 	assert.Equal(t, false, cfg.Strict)
 	assert.Equal(t, Lockfile{}, cfg.Lockfile)
 	assert.Equal(t, false, cfg.NoRollback)
@@ -1035,7 +1035,7 @@ func TestNewConfigNonDefaults(t *testing.T) {
 	assert.Equal(t, true, cfg.NoUpdate)
 	assert.Equal(t, true, cfg.Suggests)
 	assert.Empty(t, cfg.Customizations) // Customizations are tested elsewhere.
-	assert.Equal(t, []map[string]string{{"CRAN": "https://cran.microsoft.com/snapshot/2020-05-01"}}, cfg.Repos)
+	assert.Equal(t, []map[string]string{{"MPN": "https://mpn.metworx.com/snapshots/stable/2023-06-29"}}, cfg.Repos)
 	assert.Equal(t, true, cfg.Strict)
 	assert.Equal(t, Lockfile{
 		Type: "renv",

--- a/configlib/testsite/integration_test_archive/customization/pkgr.yml
+++ b/configlib/testsite/integration_test_archive/customization/pkgr.yml
@@ -7,8 +7,8 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.microsoft.com/snapshot/2019-11-01"
-  - CRAN2: "https://cran.microsoft.com/snapshot/2020-05-01"
+  - MPN: "https://mpn.metworx.com/snapshots/stable/2023-05-14"
+  - MPN2: "https://mpn.metworx.com/snapshots/stable/2023-06-29"
 
 Library: "test-library"
 
@@ -17,11 +17,11 @@ Customizations:
     - pillar:
         Type: source
         Suggests: false
-        Repo: CRAN2
+        Repo: MPN2
     - R6:
         Type: binary
         Suggests: true
-        Repo: CRAN
+        Repo: MPN
   Repos:
-    - CRAN:
+    - MPN:
         Type: source

--- a/configlib/testsite/integration_test_archive/repo-order/pkgr.yml
+++ b/configlib/testsite/integration_test_archive/repo-order/pkgr.yml
@@ -5,7 +5,7 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.microsoft.com/snapshot/2020-05-01"
+  - MPN: "https://mpn.metworx.com/snapshots/stable/2023-06-29"
   - r_validated: "https://metrumresearchgroup.github.io/r_validated"
 
 Library: "test-library"

--- a/configlib/testsite/integration_test_archive/simple-suggests/pkgr.yml
+++ b/configlib/testsite/integration_test_archive/simple-suggests/pkgr.yml
@@ -8,7 +8,7 @@ Suggests: true
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.microsoft.com/snapshot/2020-05-01"
+  - MPN: "https://mpn.metworx.com/snapshots/stable/2023-06-29"
 
 Library: "test-library"
 

--- a/configlib/testsite/integration_test_archive/simple/pkgr.yml
+++ b/configlib/testsite/integration_test_archive/simple/pkgr.yml
@@ -6,7 +6,6 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.microsoft.com/snapshot/2020-05-01"
-
+  - MPN: "https://mpn.metworx.com/snapshots/stable/2023-06-29"
 
 Library: "test-library"

--- a/configlib/testsite/many-settings/pkgr.yml
+++ b/configlib/testsite/many-settings/pkgr.yml
@@ -10,7 +10,7 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.microsoft.com/snapshot/2020-05-01"
+  - MPN: "https://mpn.metworx.com/snapshots/stable/2023-06-29"
 
 Cache: ./localcache
 

--- a/configlib/testsite/packrat-library/pkgr.yml
+++ b/configlib/testsite/packrat-library/pkgr.yml
@@ -9,6 +9,6 @@ Lockfile:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.microsoft.com/snapshot/2020-05-01"
+  - MPN: "https://mpn.metworx.com/snapshots/stable/2023-06-29"
 
 #Library: "test-library"

--- a/configlib/testsite/renv-library/pkgr.yml
+++ b/configlib/testsite/renv-library/pkgr.yml
@@ -9,6 +9,6 @@ Lockfile:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.microsoft.com/snapshot/2020-05-01"
+  - MPN: "https://mpn.metworx.com/snapshots/stable/2023-06-29"
 
 #Library: "test-library"

--- a/configlib/testsite/simple/pkgr.yml
+++ b/configlib/testsite/simple/pkgr.yml
@@ -6,7 +6,7 @@ Packages:
 
 # any repositories, order matters
 Repos:
-  - CRAN: "https://cran.microsoft.com/snapshot/2020-05-01"
+  - MPN: "https://mpn.metworx.com/snapshots/stable/2023-06-29"
 
 
 Library: "test-library"

--- a/cran/pkg_nexus_test.go
+++ b/cran/pkg_nexus_test.go
@@ -20,18 +20,18 @@ func TestSetType(t *testing.T) {
 }
 
 func TestSetType2(t *testing.T) {
-	var pkgName = "sankey"
+	var pkgName = "mrgsolve"
 	var urls = []RepoURL{
 		RepoURL{
-			Name: "CRAN_2018_11_11",
-			URL:  "https://cran.microsoft.com/snapshot/2018-11-11",
+			Name: "MPN_2023_03_13",
+			URL:  "https://mpn.metworx.com/snapshots/stable/2023-03-13",
 		},
 	}
 	var installConfig = InstallConfig{
 		Packages: map[string]PkgConfig{},
 	}
 
-	pkgNexus, _ := NewPkgDb(urls, Source, &installConfig, RVersion{}, false)
+	pkgNexus, _ := NewPkgDb(urls, Source, &installConfig, RVersion{4, 1, 3}, false)
 	_, pkgCfg, _ := pkgNexus.GetPackage(pkgName)
 	assert.Equal(t, Source, pkgCfg.Type, "Error getting type source")
 
@@ -46,27 +46,27 @@ func TestSetType2(t *testing.T) {
 }
 
 func TestSetRepo(t *testing.T) {
-	var pkgName = "sankey"
+	var pkgName = "mrgsolve"
 	var urls = []RepoURL{
 		RepoURL{
-			Name: "CRAN_2018_11_11",
-			URL:  "https://cran.microsoft.com/snapshot/2018-11-11",
+			Name: "MPN_2023_03_13",
+			URL:  "https://mpn.metworx.com/snapshots/stable/2023-03-13",
 		},
 		RepoURL{
-			Name: "CRAN_2018_11_12",
-			URL:  "https://cran.microsoft.com/snapshot/2018-11-12",
+			Name: "MPN_2022_06_15",
+			URL:  "https://mpn.metworx.com/snapshots/stable/2022-06-15",
 		},
 	}
 	var installConfig = InstallConfig{
 		Packages: map[string]PkgConfig{},
 	}
 
-	pkgNexus, _ := NewPkgDb(urls, Source, &installConfig, RVersion{}, false)
+	pkgNexus, _ := NewPkgDb(urls, Source, &installConfig, RVersion{4, 1, 3}, false)
 
 	_, pkgCfg, _ := pkgNexus.GetPackage(pkgName)
-	assert.Equal(t, "CRAN_2018_11_11", pkgCfg.Repo.Name, "Error getting repo CRAN_2018_11_11")
+	assert.Equal(t, "MPN_2023_03_13", pkgCfg.Repo.Name, "Error getting repo MPN_2023_03_13")
 
-	pkgNexus.SetPackageRepo(pkgName, "CRAN_2018_11_12")
+	pkgNexus.SetPackageRepo(pkgName, "MPN_2022_06_15")
 	_, pkgCfg, _ = pkgNexus.GetPackage(pkgName)
-	assert.Equal(t, "CRAN_2018_11_12", pkgCfg.Repo.Name, "Error setting repo CRAN_2018_11_12")
+	assert.Equal(t, "MPN_2022_06_15", pkgCfg.Repo.Name, "Error getting repo MPN_2022_06_15")
 }

--- a/cran/utils_test.go
+++ b/cran/utils_test.go
@@ -16,10 +16,10 @@ func TestUrlHash(t *testing.T) {
 	}{
 		{
 			RepoURL{
-				Name: "CRAN",
-				URL:  "https://cran.microsoft.com/snapshot/2018-11-11",
+				Name: "MPN",
+				URL:  "https://mpn.metworx.com/snapshots/stable/2023-05-14",
 			},
-			"CRAN-6a482b33cea8",
+			"MPN-8520d4ecc108",
 		},
 		{
 			RepoURL{

--- a/gpsr/helpers_test.go
+++ b/gpsr/helpers_test.go
@@ -20,8 +20,8 @@ func TestAppendGraph(t *testing.T) {
 	}
 	var urls = []cran.RepoURL{
 		cran.RepoURL{
-			Name: "CRAN",
-			URL:  "https://cran.microsoft.com/snapshot/2018-11-11",
+			Name: "MPN",
+			URL:  "https://mpn.metworx.com/snapshots/stable/2023-05-14",
 		},
 	}
 	packages := map[string]cran.PkgConfig{

--- a/gpsr/helpers_test.go
+++ b/gpsr/helpers_test.go
@@ -13,7 +13,7 @@ func TestAppendGraph(t *testing.T) {
 	workingGraph := NewGraph()
 	dependencyConfigurations := NewDefaultInstallDeps()
 	var pkgDesc = desc.Desc{
-		Package: "roxygen2", Source: "", Version: "4.1.1.9000", Maintainer: "",
+		Package: "roxygen2",
 		Imports: map[string]desc.Dep{
 			"brew": desc.Dep{Name: "brew", Version: desc.Version{Major: 0, Minor: 0, Patch: 0, Dev: 0, Other: 0}, Constraint: 0},
 		},


### PR DESCRIPTION
<https://cran.microsoft.com/> has been shut down.  Although `cran.microsoft.com` URLs occur in a good number of files, there are actually only a few places that actually try to connect.  The second and third commit of this series fixes those, and the fourth commit updates the Drone configuration so that those tests are executed.

The final commit removes some more `cran.microsoft.com` URLs, but, unlike the ones in the earlier commits, these updates aren't actually necessary because the tests don't connect.  That commit message also has an overview of the remaining occurrences of `cran.microsoft.com` URLs, all of which I think are fine to leave be at this point.

Closes #409.
