### PR TITLE
Prepare 3.1.1 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
 
+# pkgr 3.1.1
+
+* Fixed renv detection when other startup code writes to stdout. (#408)
+
+
 # pkgr 3.1.0
 
 * For `Lockfile: Type: renv`, pkgr now invokes `renv` to discover the


### PR DESCRIPTION
The only user-facing change is the renv detection fix from gh-408.

changeset: https://github.com/metrumresearchgroup/pkgr/compare/273972eb7decbabddd7875ee7095e61661f12884...092c8f5a3f7f494af5934882f62005bf7d0dd386
