### PR TITLE
Add a few tests

### DIFF
--- a/cmd/descriptionOps_test.go
+++ b/cmd/descriptionOps_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnpackDescriptions(t *testing.T) {
+	// This is just a light test that unpackDescriptions is wired up.  The desc
+	// package has more detailed tests of DESCRIPTION parsing.
+	descFoo := []byte(`Package: foo
+Version: 0.4.0
+`)
+	descBar := []byte(`Package: bar
+Version: 1.0.0
+License: GPL (>=2)
+`)
+
+	dir := t.TempDir()
+	err := os.Mkdir(filepath.Join(dir, "foo"), 0o777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Mkdir(filepath.Join(dir, "bar"), 0o777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foo := filepath.Join(dir, "foo", "DESCRIPTION")
+	bar := filepath.Join(dir, "bar", "DESCRIPTION")
+
+	err = os.WriteFile(foo, descFoo, 0o666)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(bar, descBar, 0o666)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := unpackDescriptions(afero.NewOsFs(), []string{foo, bar})
+	assert.Equal(t, res[0].Package, "foo")
+	assert.Equal(t, res[0].Version, "0.4.0")
+	assert.Equal(t, res[1].Package, "bar")
+	assert.Equal(t, res[1].Version, "1.0.0")
+	assert.Equal(t, res[1].License, "GPL (>=2)")
+}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -41,7 +41,7 @@ func init() {
 func rRemove(ccmd *cobra.Command, args []string) error {
 
 	// Initialize log and start time.
-	initAddLog()
+	initRemoveLog()
 	startTime := time.Now()
 
 	if len(args) == 0 {

--- a/docs/validation/matrix.yaml
+++ b/docs/validation/matrix.yaml
@@ -6,6 +6,7 @@
   doc: docs/commands/pkgr_add.md
   tests:
     - configlib/add_package_test.go
+    - integration_tests/addremove/addremove_test.go
 
 - entrypoint: pkgr clean
   code: cmd/clean.go
@@ -73,6 +74,7 @@
   doc: docs/commands/pkgr_remove.md
   tests:
     - configlib/config_test.go
+    - integration_tests/addremove/addremove_test.go
 
 - entrypoint: pkgr run
   code: cmd/run.go

--- a/integration_tests/addremove/addremove_test.go
+++ b/integration_tests/addremove/addremove_test.go
@@ -1,0 +1,140 @@
+package addremove
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/metrumresearchgroup/command"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+
+	"github.com/metrumresearchgroup/pkgr/configlib"
+)
+
+func TestAddRemove(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := &configlib.PkgrConfig{
+		Version: 1,
+		Packages: []string{
+			"foo",
+			"bar",
+		},
+		Repos: []map[string]string{
+			{
+				"MPN": "mpn",
+			},
+		},
+		Library: "lib",
+		Cache:   "cache",
+	}
+
+	bs, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkgrfile := filepath.Join(dir, "pkgr.yml")
+	err = os.WriteFile(pkgrfile, bs, 0o666)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("add", func(t *testing.T) {
+		cmd := command.New("pkgr", "add", "baz1", "baz2")
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s\n%s\n", out, err)
+		}
+
+		bsNew, err := os.ReadFile(pkgrfile)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var cfgNew configlib.PkgrConfig
+		err = yaml.Unmarshal(bsNew, &cfgNew)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Contains(t, cfgNew.Packages, "foo")
+		assert.Contains(t, cfgNew.Packages, "bar")
+		assert.Contains(t, cfgNew.Packages, "baz1")
+		assert.Contains(t, cfgNew.Packages, "baz2")
+	})
+
+	t.Run("remove", func(t *testing.T) {
+		cmd := command.New("pkgr", "remove", "foo", "baz1")
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s\n%s\n", out, err)
+		}
+
+		bsNew, err := os.ReadFile(pkgrfile)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var cfgNew configlib.PkgrConfig
+		err = yaml.Unmarshal(bsNew, &cfgNew)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.NotContains(t, cfgNew.Packages, "foo")
+		assert.Contains(t, cfgNew.Packages, "bar")
+		assert.NotContains(t, cfgNew.Packages, "baz1")
+		assert.Contains(t, cfgNew.Packages, "baz2")
+	})
+}
+
+func TestAddInstall(t *testing.T) {
+	dir := t.TempDir()
+
+	repo, err := filepath.Abs("../../localrepos/simple")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &configlib.PkgrConfig{
+		Version: 1,
+		Packages: []string{
+			"R6",
+		},
+		Repos: []map[string]string{
+			{
+				"local": repo,
+			},
+		},
+		Customizations: configlib.Customizations{
+			Repos: []map[string]configlib.RepoConfig{
+				{
+					"local": {
+						Type: "Source",
+					},
+				},
+			},
+		},
+		Library: "lib",
+		Cache:   "cache",
+	}
+
+	bs, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(filepath.Join(dir, "pkgr.yml"), bs, 0o666)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := command.New("pkgr", "add", "--install", "cli")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s\n%s\n", out, err)
+	}
+
+	assert.DirExists(t, filepath.Join(dir, "lib", "R6"))
+	assert.DirExists(t, filepath.Join(dir, "lib", "cli"))
+}

--- a/scripts/run-integration-tests
+++ b/scripts/run-integration-tests
@@ -44,6 +44,7 @@ git clean -xfq \
 
 test_dir=$PWD/integration_tests
 subdirs='
+  addremove
   bad-customization
   baseline
   env-vars


### PR DESCRIPTION
This PR adds tests for the zero-coverage files that remain in the per file report after gh-420.  The tip commit fixes a code typo of no functional consequence.

Here's the per file coverage table generated with a scratch merge of this PR and gh-420.

<details>
<summary>table</summary>

```
$ git rev-parse f2bfecc^{tree}
50a826a7257484d1498dd1e5f3b31b6cb54d6662

$ jq -r '.files | .[] | [.file, .coverage] | @tsv' \
  <internal/valtools/output/pkgr_3.1.1-59-gf2bfecc/pkgr_3.1.1-59-gf2bfecc.coverage.json | \
  sort -k2 -g | awk '{printf "%s\t%.2f\n", $1,$2}' | column -t
testhelper/e2e_tests.go         1.69
cmd/debug.go                    9.09
cmd/run.go                      22.22
cmd/experiment.go               25.00
logger/logger.go                31.43
gpsr/install.go                 50.00
cran/utils.go                   53.85
rcmd/RunR.go                    58.33
desc/version.go                 60.00
cmd/inspect.go                  60.47
rollback/operations.go          61.02
rcmd/utils.go                   66.67
cmd/cleanCache.go               68.67
cran/pkg_nexus.go               68.82
testhelper/fileio.go            70.83
pacman/utils.go                 71.93
cran/repodb.go                  72.67
cran/sync.go                    72.73
rcmd/helpers.go                 73.33
cran/download-package.go        73.83
cmd/tarballOps.go               75.00
desc/structs.go                 75.00
cmd/remove.go                   76.92
cmd/pkgr/pkgr.go                80.00
desc/desc.go                    80.70
cmd/add.go                      81.25
cmd/clean.go                    81.25
cmd/plan.go                     81.70
cmd/cleanPkgdb.go               81.82
cmd/descriptionOps.go           81.82
cmd/install.go                  83.78
configlib/config.go             83.97
rcmd/Rsettings.go               86.05
configlib/add_package.go        86.96
rcmd/worker.go                  87.10
rcmd/cache.go                   87.50
rcmd/install.go                 87.78
gpsr/solution.go                88.64
cmd/utils.go                    88.89
cmd/load.go                     90.91
configlib/get_customization.go  91.67
rcmd/configure.go               91.84
rcmd/nvp.go                     92.86
cmd/root.go                     93.33
rollback/types.go               93.55
gpsr/dependencies.go            93.75
gpsr/helpers.go                 95.24
cmd/structs.go                  100.00
cran/config.go                  100.00
cran/pkgdl.go                   100.00
cran/r_version.go               100.00
cran/structs.go                 100.00
desc/dep.go                     100.00
rcmd/rp/lines.go                100.00
```

</details>

